### PR TITLE
Handle uppercase Y/N in uninstall script

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,71 +1,74 @@
 #!/usr/bin/env bash
 set -e
-# set to 1 to not ask user any questions
+# Set to 1 to skip prompts.
 NO_INTERACTION=0
 
 main() {
-  while getopts "n" o; do
-    case ${o} in
-      n)
-        NO_INTERACTION=1
-        ;;
-    esac
-  done
+    while getopts "n" option; do
+        case ${option} in
+            n)
+                NO_INTERACTION=1
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    done
 
-  # Confirm with user they really want to uninstall PMS
-  if [ "$NO_INTERACTION" -eq "0" ]; then
-    read -r -p "Are you sure you want to uninstall PMS? [y/N] " confirm
-    if [ "$confirm" != "y" ] && [ "$config" != "Y" ]; then
-      echo "Canceled"
-      exit
-    fi
-  fi
-
-  # Revert rc files (user confirmation)
-  if [ -f ~/.bashrc.pms.bak ] && [ -f ~/.bashrc ]; then
+    # Confirm with user they really want to uninstall PMS
     if [ "$NO_INTERACTION" -eq "0" ]; then
-      read -r -p "Restore your ~/.bashrc with the backup ~/.bashrc.pms.bak? [Y/n] " confirm
-      if [ "$confirm" != "n" ] && [ "$config" != "N" ]; then
-        mv ~/.bashrc.pms.bak ~/.bashrc
-      fi
-    else
-      mv ~/.bashrc.pms.bak ~/.bashrc
+        read -r -p "Are you sure you want to uninstall PMS? [y/N] " confirm
+        if [ "${confirm}" != "y" ] && [ "${confirm}" != "Y" ]; then
+            echo "Canceled"
+            exit
+        fi
     fi
-  fi
-  if [ -f ~/.zshrc.pms.bak ] && [ -f ~/.zshrc ]; then
-    if [ "$NO_INTERACTION" -eq "0" ]; then
-      read -r -p "Restore your ~/.zshrc with the backup ~/.zshrc.pms.bak? [Y/n] " confirm
-      if [ "$confirm" != "n" ] && [ "$config" != "N" ]; then
-        mv ~/.zshrc.pms.bak ~/.zshrc
-      fi
-    else
-      mv ~/.zshrc.pms.bak ~/.zshrc
+
+    # Revert rc files (user confirmation)
+    if [ -f ~/.bashrc.pms.bak ] && [ -f ~/.bashrc ]; then
+        if [ "$NO_INTERACTION" -eq "0" ]; then
+            read -r -p "Restore your ~/.bashrc with the backup ~/.bashrc.pms.bak? [Y/n] " confirm
+            if [ "${confirm}" != "n" ] && [ "${confirm}" != "N" ]; then
+                mv ~/.bashrc.pms.bak ~/.bashrc
+            fi
+        else
+            mv ~/.bashrc.pms.bak ~/.bashrc
+        fi
     fi
-  fi
-
-  # Delete PMS Config files
-  echo "Removing ~/.pms.theme file"
-  rm -fv ~/.pms.theme
-  echo "Removing ~/.pms.plugins file"
-  rm -fv ~/.pms.plugins
-
-  # Delete .env (user confirmation)
-  if [ -f ~/.env ]; then
-    if [ "$NO_INTERACTION" -eq "0" ]; then
-      read -r -p "Would you like to delete ~/.env file? [Y/n] " confirm
-      if [ "$confirm" != "n" ] && [ "$config" != "N" ]; then
-        rm -fv ~/.env
-      fi
-    else
-      rm -fv ~/.env
+    if [ -f ~/.zshrc.pms.bak ] && [ -f ~/.zshrc ]; then
+        if [ "$NO_INTERACTION" -eq "0" ]; then
+            read -r -p "Restore your ~/.zshrc with the backup ~/.zshrc.pms.bak? [Y/n] " confirm
+            if [ "${confirm}" != "n" ] && [ "${confirm}" != "N" ]; then
+                mv ~/.zshrc.pms.bak ~/.zshrc
+            fi
+        else
+            mv ~/.zshrc.pms.bak ~/.zshrc
+        fi
     fi
-  fi
 
-  # Delete $PMS directory
-  echo "Removing ~/.pms directory"
-  rm -rf ~/.pms
+    # Delete PMS Config files
+    echo "Removing ~/.pms.theme file"
+    rm -fv ~/.pms.theme
+    echo "Removing ~/.pms.plugins file"
+    rm -fv ~/.pms.plugins
 
-  echo "PMS has been uninstalled. You should restart your terminal"
+    # Delete .env (user confirmation)
+    if [ -f ~/.env ]; then
+        if [ "$NO_INTERACTION" -eq "0" ]; then
+            read -r -p "Would you like to delete ~/.env file? [Y/n] " confirm
+            if [ "${confirm}" != "n" ] && [ "${confirm}" != "N" ]; then
+                rm -fv ~/.env
+            fi
+        else
+            rm -fv ~/.env
+        fi
+    fi
+
+    # Delete $PMS directory
+    echo "Removing ~/.pms directory"
+    rm -rf ~/.pms
+
+    echo "PMS has been uninstalled. You should restart your terminal"
 }
 
 main "$@"

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+@test "uninstall aborts on uppercase N" {
+    HOME="$BATS_TMPDIR"
+    touch "$HOME/.pms.theme"
+    run bash -c "printf 'N\n' | scripts/uninstall.sh"
+    [ "$status" -eq 0 ]
+    [ -f "$HOME/.pms.theme" ]
+    [[ "$output" == *Canceled* ]]
+}
+
+@test "uninstall removes files on uppercase Y" {
+    HOME="$BATS_TMPDIR"
+    mkdir "$HOME/.pms"
+    touch "$HOME/.pms.theme"
+    run bash -c "printf 'Y\n' | scripts/uninstall.sh"
+    [ "$status" -eq 0 ]
+    [ ! -f "$HOME/.pms.theme" ]
+    [ ! -d "$HOME/.pms" ]
+    [[ "$output" == *"PMS has been uninstalled"* ]]
+}


### PR DESCRIPTION
## Summary
- support uppercase Y/N confirmations in uninstall script
- add default option handling and tidy formatting
- add bats tests for non-interactive Y/N handling

## Testing
- `shellcheck scripts/uninstall.sh`
- `bats tests/uninstall.bats`


------
https://chatgpt.com/codex/tasks/task_e_68a51b65808c832c9da86e6d275dad20