### PR TITLE
Honor PMS_SHELL during installation

### DIFF
--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -7,10 +7,19 @@ title: Installation
 Installing can be done quick and easy by using curl. The installation process
 will not overwrite any files and will backup your current rc files.
 
+Set the `PMS_SHELL` environment variable to target a specific shell. If not
+set, the installer uses your current shell.
+
 ## Using curl
 
 ```sh
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/JoshuaEstes/pms/main/scripts/install.sh)"
+```
+
+To install for zsh:
+
+```sh
+PMS_SHELL=zsh sh -c "$(curl -fsSL https://raw.githubusercontent.com/JoshuaEstes/pms/main/scripts/install.sh)"
 ```
 
 ## Using wget


### PR DESCRIPTION
## Summary
- Allow installers to target a specific shell via `PMS_SHELL`
- Configure only the chosen shell's rc file and set default shell when possible
- Document shell selection flag in installation guide

## Testing
- `shellcheck scripts/install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a51b676e74832c9cc2742b0ef4b28c