### PR TITLE
feat: add prompt helper and refactor scripts

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,3 +17,5 @@
   * [\_\_PLUGIN\_\_ Template](plugins/plugin\_templates\_for\_docs.md)
 * [Themes](themes/README.md)
   * [default](themes/default.md)
+* [Developer Guides](developer/README.md)
+  * [Prompt Helper](developer/prompt-helper.md)

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,7 @@
+---
+title: Developer Guides
+---
+
+# Developer Guides
+
+Guides for extending and contributing to PMS.

--- a/docs/developer/prompt-helper.md
+++ b/docs/developer/prompt-helper.md
@@ -1,0 +1,22 @@
+---
+title: Prompt Helper
+---
+
+# _pms_prompt
+
+The `_pms_prompt` function simplifies asking users for input from shell scripts.
+It supports optional default values and validation patterns.
+
+## Usage
+
+```sh
+response=$(_pms_prompt "Continue? [y/N]" "n" "[yYnN]")
+```
+
+Parameters:
+
+1. **Prompt** – message displayed to the user.
+2. **Default** – value used when the user presses enter.
+3. **Validation** – optional regular expression the response must match.
+
+The validated response is printed to standard output for assignment.

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -13,8 +13,38 @@
 ####
 
 ####
-# @todo Interactive Helpers
-# Allows PMS to ask questions and get confirmations from the user
+# Ask the user for input with optional default and validation
+#
+# Usage: _pms_prompt "Prompt" "default" "regex"
+#
+# Examples:
+#   name=$(_pms_prompt "Name?")
+#   color=$(_pms_prompt "Color?" "blue")
+#   answer=$(_pms_prompt "Continue? [y/N]" "n" "[yYnN]")
+####
+_pms_prompt() {
+    local prompt_message="$1"
+    local default_value="$2"
+    local validation_pattern="${3:-.*}"
+    local user_input
+
+    while true; do
+        if [ -n "$default_value" ]; then
+            printf "%s [%s] " "$prompt_message" "$default_value"
+        else
+            printf "%s " "$prompt_message"
+        fi
+        IFS= read -r user_input
+        if [ -z "$user_input" ] && [ -n "$default_value" ]; then
+            user_input="$default_value"
+        fi
+        if printf '%s' "$user_input" | grep -Eq "^(${validation_pattern})$"; then
+            printf '%s' "$user_input"
+            return 0
+        fi
+        echo "Invalid response"
+    done
+}
 
 ####
 # Used to ask the user a yes/no question

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,46 +16,65 @@ PMS_REPO=${PMS_REPO:-JoshuaEstes/pms}
 PMS_REMOTE=${PMS_REMOTE:-https://github.com/${PMS_REPO}.git}
 PMS_BRANCH=${PMS_BRANCH:-main}
 
+_copy_file() {
+    src_file="$1"
+    dest_file="$2"
+    desc="$3"
+
+    if [ -e "$dest_file" ]; then
+        overwrite=$(_pms_prompt "Overwrite existing $desc? [y/N]" "n" "[yYnN]")
+        case "$overwrite" in
+            y|Y) cp -vf "$src_file" "$dest_file";;
+            *) printf 'Skipping %s\n' "$desc";;
+        esac
+    else
+        cp -vf "$src_file" "$dest_file"
+    fi
+}
+
 setup_pms() {
-    echo "\r\n\t${BLUE}Cloning PMS...${RESET}\n\n"
+    printf "\r\n\t%sCloning PMS...%s\n\n" "$BLUE" "$RESET"
 
     git clone --depth=1 --branch "$PMS_BRANCH" "$PMS_REMOTE" "$PMS" || {
         echo "${RED}ERROR: git clone command failed${RESET}"
         exit 1
     }
 
+    # shellcheck source=lib/core.sh
+    . "$PMS/lib/core.sh"
+
     # Copy over config files if they do not currently exist
-    echo "${BLUE}Copying PMS Environment Variables file over, this file stores various PMS settings that can be modified${RESET}"
-    cp -vfi $PMS/templates/env ~/.env
+    printf "%sCopying PMS Environment Variables file over, this file stores various PMS settings that can be modified%s\n" "$BLUE" "$RESET"
+    _copy_file "$PMS/templates/env" "$HOME/.env" "$HOME/.env"
 
-    echo "${BLUE}Copying PMS Theme Config File, this file is used to store your currently selected theme${RESET}"
-    cp -vfi $PMS/templates/pms.theme ~/.pms.theme
+    printf "%sCopying PMS Theme Config File, this file is used to store your currently selected theme%s\n" "$BLUE" "$RESET"
+    _copy_file "$PMS/templates/pms.theme" "$HOME/.pms.theme" "$HOME/.pms.theme"
 
-    echo "${BLUE}Copying PMS Plugins Config File, this file contains all your enabled plugins${RESET}"
-    cp -vfi $PMS/templates/pms.plugins ~/.pms.plugins
+    printf "%sCopying PMS Plugins Config File, this file contains all your enabled plugins%s\n" "$BLUE" "$RESET"
+    _copy_file "$PMS/templates/pms.plugins" "$HOME/.pms.plugins" "$HOME/.pms.plugins"
 }
 
 _setup_shell_rc() {
     # @todo better support
-    if [ -f ~/.$1 ] || [ -h ~/.$1 ]; then
-        echo "${YELLOW}Found existing .$1 file, backing up${RESET}"
-        if [ ! -f ~/.$1.pms.bak ]; then
-            echo "${YELLOW}Moving ~/.$1 -> ~/.$1.pms.bak${RESET}"
-            mv -vfi ~/.$1 ~/.$1.pms.bak
+    if [ -f "$HOME/.$1" ] || [ -h "$HOME/.$1" ]; then
+        printf "%sFound existing .$1 file, backing up%s\n" "$YELLOW" "$RESET"
+        if [ ! -f "$HOME/.$1.pms.bak" ]; then
+            printf "%sMoving $HOME/.$1 -> $HOME/.$1.pms.bak%s\n" "$YELLOW" "$RESET"
+            mv -vfi "$HOME/.$1" "$HOME/.$1.pms.bak"
         fi
     fi
-    echo "${BLUE}Copy $PMS/templates/$1 -> ~/.$1 ${RESET}"
-    cp -vf $PMS/templates/$1 ~/.$1
+    printf "%sCopy $PMS/templates/$1 -> $HOME/.$1 %s\n" "$BLUE" "$RESET"
+    cp -vf "$PMS/templates/$1" "$HOME/.$1"
 }
 
 setup_rcfiles() {
-    echo "\r\n\t${BLUE}Setting up rc files...${RESET}\n\n"
+    printf "\r\n\t%sSetting up rc files...%s\n\n" "$BLUE" "$RESET"
     _setup_shell_rc bashrc
     _setup_shell_rc zshrc
 }
 
 setup_shell() {
-    echo "\r\n\t${BLUE}Setting up shell...${RESET}\n\n"
+    printf "\r\n\t%sSetting up shell...%s\n\n" "$BLUE" "$RESET"
     # @todo
 }
 
@@ -78,13 +97,13 @@ main() {
   fi
 
   if [ "$PMS_DEBUG" -eq "1" ]; then
-    printf "${YELLOW}"
+    printf '%s' "$YELLOW"
     echo "PMS:         $PMS"
     echo "PMS_DEBUG:   $PMS_DEBUG"
     echo "PMS_REPO:    $PMS_REPO"
     echo "PMS_REMOTE:  $PMS_REMOTE"
     echo "PMS_BRANCH:  $PMS_BRANCH"
-    printf "${RESET}"
+    printf '%s' "$RESET"
   fi
 
   if [ ! -x "$(command -v git)" ]; then
@@ -106,7 +125,7 @@ main() {
   setup_rcfiles
   setup_shell
 
-  printf "${GREEN}"
+  printf '%s' "$GREEN"
 cat <<-'EOF'
 
 Thanks for installing...
@@ -137,7 +156,7 @@ Developer Guides - https://github.com/JoshuaEstes/pms/wiki
 
 
 EOF
-  printf "${RESET}"
+  printf '%s' "$RESET"
 }
 
 main "$@"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,70 +2,76 @@
 set -e
 # set to 1 to not ask user any questions
 NO_INTERACTION=0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=../lib/core.sh
+. "$SCRIPT_DIR/../lib/core.sh"
 
 main() {
-  while getopts "n" o; do
-    case ${o} in
-      n)
-        NO_INTERACTION=1
-        ;;
-    esac
-  done
+    while getopts "n" o; do
+        case ${o} in
+            n)
+                NO_INTERACTION=1
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    done
 
-  # Confirm with user they really want to uninstall PMS
-  if [ "$NO_INTERACTION" -eq "0" ]; then
-    read -r -p "Are you sure you want to uninstall PMS? [y/N] " confirm
-    if [ "$confirm" != "y" ] && [ "$config" != "Y" ]; then
-      echo "Canceled"
-      exit
+    # Confirm with user they really want to uninstall PMS
+    if [ "$NO_INTERACTION" -eq 0 ]; then
+        confirm=$(_pms_prompt "Are you sure you want to uninstall PMS? [y/N]" "n" "[yYnN]")
+        case "$confirm" in
+            y|Y) ;;
+            *) echo "Canceled"; exit 0;;
+        esac
     fi
-  fi
 
-  # Revert rc files (user confirmation)
-  if [ -f ~/.bashrc.pms.bak ] && [ -f ~/.bashrc ]; then
-    if [ "$NO_INTERACTION" -eq "0" ]; then
-      read -r -p "Restore your ~/.bashrc with the backup ~/.bashrc.pms.bak? [Y/n] " confirm
-      if [ "$confirm" != "n" ] && [ "$config" != "N" ]; then
-        mv ~/.bashrc.pms.bak ~/.bashrc
-      fi
-    else
-      mv ~/.bashrc.pms.bak ~/.bashrc
+    # Revert rc files (user confirmation)
+    if [ -f ~/.bashrc.pms.bak ] && [ -f ~/.bashrc ]; then
+        if [ "$NO_INTERACTION" -eq 0 ]; then
+            confirm=$(_pms_prompt "Restore your ~/.bashrc with the backup ~/.bashrc.pms.bak? [Y/n]" "y" "[yYnN]")
+            case "$confirm" in
+                y|Y) mv ~/.bashrc.pms.bak ~/.bashrc;;
+            esac
+        else
+            mv ~/.bashrc.pms.bak ~/.bashrc
+        fi
     fi
-  fi
-  if [ -f ~/.zshrc.pms.bak ] && [ -f ~/.zshrc ]; then
-    if [ "$NO_INTERACTION" -eq "0" ]; then
-      read -r -p "Restore your ~/.zshrc with the backup ~/.zshrc.pms.bak? [Y/n] " confirm
-      if [ "$confirm" != "n" ] && [ "$config" != "N" ]; then
-        mv ~/.zshrc.pms.bak ~/.zshrc
-      fi
-    else
-      mv ~/.zshrc.pms.bak ~/.zshrc
+    if [ -f ~/.zshrc.pms.bak ] && [ -f ~/.zshrc ]; then
+        if [ "$NO_INTERACTION" -eq 0 ]; then
+            confirm=$(_pms_prompt "Restore your ~/.zshrc with the backup ~/.zshrc.pms.bak? [Y/n]" "y" "[yYnN]")
+            case "$confirm" in
+                y|Y) mv ~/.zshrc.pms.bak ~/.zshrc;;
+            esac
+        else
+            mv ~/.zshrc.pms.bak ~/.zshrc
+        fi
     fi
-  fi
 
-  # Delete PMS Config files
-  echo "Removing ~/.pms.theme file"
-  rm -fv ~/.pms.theme
-  echo "Removing ~/.pms.plugins file"
-  rm -fv ~/.pms.plugins
+    # Delete PMS Config files
+    echo "Removing ~/.pms.theme file"
+    rm -fv ~/.pms.theme
+    echo "Removing ~/.pms.plugins file"
+    rm -fv ~/.pms.plugins
 
-  # Delete .env (user confirmation)
-  if [ -f ~/.env ]; then
-    if [ "$NO_INTERACTION" -eq "0" ]; then
-      read -r -p "Would you like to delete ~/.env file? [Y/n] " confirm
-      if [ "$confirm" != "n" ] && [ "$config" != "N" ]; then
-        rm -fv ~/.env
-      fi
-    else
-      rm -fv ~/.env
+    # Delete .env (user confirmation)
+    if [ -f ~/.env ]; then
+        if [ "$NO_INTERACTION" -eq 0 ]; then
+            confirm=$(_pms_prompt "Would you like to delete ~/.env file? [Y/n]" "y" "[yYnN]")
+            case "$confirm" in
+                y|Y) rm -fv ~/.env;;
+            esac
+        else
+            rm -fv ~/.env
+        fi
     fi
-  fi
 
-  # Delete $PMS directory
-  echo "Removing ~/.pms directory"
-  rm -rf ~/.pms
+    # Delete $PMS directory
+    echo "Removing ~/.pms directory"
+    rm -rf ~/.pms
 
-  echo "PMS has been uninstalled. You should restart your terminal"
+    echo "PMS has been uninstalled. You should restart your terminal"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- add reusable `_pms_prompt` for interactive input
- refactor install and uninstall scripts to use prompt helper
- document prompt helper in developer guides

## Testing
- `shellcheck -x lib/core.sh scripts/install.sh scripts/uninstall.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a51b6a9820832caa00c5ea2fca9777