### PR TITLE
feat: improve help command for subcommands

### DIFF
--- a/docs/pms-manager.md
+++ b/docs/pms-manager.md
@@ -8,6 +8,16 @@ The PMS Manager is what you will use most of the time when you want to interact 
 
 You can run `pms help` at any time to get information on all the commands the PMS Manager supports.
 
+## Getting Help
+
+Use `pms help` to list available commands. For detailed help on a specific command or subcommand, run:
+
+```shell
+pms help plugin
+pms help plugin enable
+pms help theme switch
+```
+
 ## Managing Plugins
 
 Plugins modify shell behaviour such as loading auto-completion scripts, adding aliases, or modifying shell options. Plugins are managed using the `pms plugin` command.
@@ -32,7 +42,7 @@ pms plugin disable [PLUGIN]
 
 ## Managing Themes
 
-Themes will modify how you shell looks. These are things such as colors and usually includes a kick ass command prompt.
+Themes modify how your shell looks. These are things such as colors and usually include a kick ass command prompt.
 
 _**Note**_ Some themes may enable or disable PMS plugins for functionality. An example of this would be a theme that would require the "git-prompt" plugin so it has access to that functionality. This is done for you so you don't need to do this by hand {: .notice--warning}
 
@@ -84,7 +94,7 @@ git --git-dir=$HOME/.dotfiles --work-tree=$HOME -C $HOME checkout
 git --git-dir=$HOME/.dotfiles --work-tree=$HOME -C $HOME config --local status.showUntrackedFiles no
 ```
 
-_**NOTE**_: You may run into issues when you run "git checkout". You will need to resolve those before you con make sure that everything is setup correctly.
+_**NOTE**_: You may run into issues when you run "git checkout". You will need to resolve those before you can make sure that everything is set up correctly.
 
 ### Adding files
 

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -57,13 +57,23 @@ EOF
     return 0
 }
 
-# @todo if there are arguments, check other help functions, example would be
-# pms help theme = _pms_command_help_theme
-# pms help theme list = _pms_command_help_theme_list
+# Display help for commands and subcommands
 __pms_command_help() {
     if [ $# -gt 0 ]; then
         local command=$1
         shift
+
+        if [ $# -gt 0 ]; then
+            local subcommand=$1
+            shift
+
+            type __pms_command_help_${command}_${subcommand} &>/dev/null && {
+                __pms_command_help_${command}_${subcommand} "$@"
+                return $?
+            }
+
+            set -- "$subcommand" "$@"
+        fi
 
         type __pms_command_help_${command} &>/dev/null && {
             __pms_command_help_${command} "$@"
@@ -277,23 +287,57 @@ __pms_command_theme() {
 }
 
 __pms_command_help_theme() {
-  echo
-  echo "Usage: pms [options] theme <command>"
-  echo
-  echo "Commands:"
-  __pms_command "list" "Displays available themes"
-  __pms_command "switch <theme>" "Switch to a specific theme"
-  __pms_command "info <theme>" "Displays information about a theme"
-  #echo "  reload             Reloads current theme"
-  #echo "  use <theme>        Temporary use theme"
-  #echo "  preview <theme>    Preview theme"
-  #echo "  validate <theme>   Validate theme"
-  #echo "  make <theme>       Creates a new theme"
-  echo
+    echo
+    echo "Usage: pms [options] theme <command>"
+    echo
+    echo "Commands:"
+    __pms_command "list" "Displays available themes"
+    __pms_command "switch <theme>" "Switch to a specific theme"
+    __pms_command "info <theme>" "Displays information about a theme"
+    #echo "  reload             Reloads current theme"
+    #echo "  use <theme>        Temporary use theme"
+    #echo "  preview <theme>    Preview theme"
+    #echo "  validate <theme>   Validate theme"
+    #echo "  make <theme>       Creates a new theme"
+    echo
+    _pms_message "Examples:"
+    _pms_message_block "pms help theme list"
+    _pms_message_block "pms help theme switch"
+    echo
 
-  # @todo Allow plugins to hook into this
+    # @todo Allow plugins to hook into this
 
-  return 0
+    return 0
+}
+
+__pms_command_help_theme_list() {
+    echo
+    echo "Usage: pms theme list"
+    echo
+    echo "Displays available themes."
+    echo
+
+    return 0
+}
+
+__pms_command_help_theme_switch() {
+    echo
+    echo "Usage: pms theme switch <theme>"
+    echo
+    echo "Switches to the specified theme."
+    echo
+
+    return 0
+}
+
+__pms_command_help_theme_info() {
+    echo
+    echo "Usage: pms theme info <theme>"
+    echo
+    echo "Displays information about a theme."
+    echo
+
+    return 0
 }
 
 __pms_command_theme_list() {
@@ -366,33 +410,77 @@ __pms_command_plugin() {
 }
 
 __pms_command_help_plugin() {
-    if [ $# -gt 0 ]; then
-        local command=$1
-        shift
+    echo
+    echo "Usage: pms [options] plugin <command>"
+    echo
+    echo "Commands:"
+    __pms_command "list" "Lists all available plugins"
+    __pms_command "enable <plugin>" "Enables and installs a plugin"
+    __pms_command "disable <plugin>" "Disables a plugin"
+    __pms_command "info <plugin>" "Displays information about a plugin"
+    __pms_command "make <plugin>" "Creates a new plugin"
+    #echo "  update <plugin>    Updates a plugin"
+    #echo "  validate <plugin>  Validate plugin"
+    #echo "  reload <plugin>    Reloads enabled plugins"
+    echo
+    _pms_message "Examples:"
+    _pms_message_block "pms help plugin enable"
+    _pms_message_block "pms help plugin list"
+    echo
 
-        type __pms_command_help_plugin_${command} &>/dev/null && {
-            __pms_command_help_plugin_${command} "$@"
-            return $?
-        }
-    fi
+    # @todo allow plugins to hook into this
 
-  echo
-  echo "Usage: pms [options] plugin [command]"
-  echo
-  echo "Commands:"
-  __pms_command "list" "Lists all available plugins"
-  __pms_command "enable <plugin>" "Enables and install plugin"
-  __pms_command "disable <plugin>" "Disables a plugin"
-  __pms_command "info <plugin>" "Displays information about a plugin"
-  __pms_command "make <plugin>" "Creates a new plugin"
-  #echo "  update <plugin>    Updates a plugin"
-  #echo "  validate <plugin>  Validate plugin"
-  #echo "  reload <plugin>    Reloads enabled plugins"
-  echo
+    return 0
+}
 
-  # @todo allow plugins to hook into this
+__pms_command_help_plugin_list() {
+    echo
+    echo "Usage: pms plugin list"
+    echo
+    echo "Lists all available plugins."
+    echo
 
-  return 0
+    return 0
+}
+
+__pms_command_help_plugin_enable() {
+    echo
+    echo "Usage: pms plugin enable <plugin>"
+    echo
+    echo "Enables and installs the specified plugin."
+    echo
+
+    return 0
+}
+
+__pms_command_help_plugin_disable() {
+    echo
+    echo "Usage: pms plugin disable <plugin>"
+    echo
+    echo "Disables the specified plugin."
+    echo
+
+    return 0
+}
+
+__pms_command_help_plugin_info() {
+    echo
+    echo "Usage: pms plugin info <plugin>"
+    echo
+    echo "Displays information about a plugin."
+    echo
+
+    return 0
+}
+
+__pms_command_help_plugin_make() {
+    echo
+    echo "Usage: pms plugin make <plugin>"
+    echo
+    echo "Creates a new plugin scaffold."
+    echo
+
+    return 0
 }
 
 # @todo Option for making this a local plugin
@@ -591,7 +679,7 @@ __pms_command_help_dotfiles() {
 }
 
 __pms_command_dotfiles_push() {
-    /usr/bin/git --git-dir=$PMS_DOTFILES_GIT_DIR --work-tree=$HOME -C $HOME push origin $PMS_DOTFILES_BRANCH
+    /usr/bin/git --git-dir="$PMS_DOTFILES_GIT_DIR" --work-tree="$HOME" -C "$HOME" push origin "$PMS_DOTFILES_BRANCH"
 }
 
 __pms_command_dotfiles_init() {
@@ -610,6 +698,8 @@ __pms_command_dotfiles_init() {
     #   git config --local status.showUntrackedFiles no
     #   git remote add origin REPO_URL
     # ---
+
+    :
 }
 
 # @todo if no arguments, add all modified files


### PR DESCRIPTION
## Summary
- handle `pms help <command> [subcommand]` by dispatching to matching help functions
- document command-specific help for themes and plugins
- extend user guide with `pms help` examples

## Testing
- `shellcheck lib/cli.sh`
- `bash -n lib/cli.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a51b6d12d4832c84c83391db40abcc