### PR TITLE
docs: document env variables

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -4,7 +4,8 @@ title: Environment Variables
 
 # Environment Variables
 
-PMS will search for and load a few different .env files to help you configure how PMS works.
+PMS will search for and load a few different .env files to help you
+configure how PMS works.
 
 .env files, if they exist, are loaded in the following order:
 
@@ -14,9 +15,38 @@ PMS will search for and load a few different .env files to help you configure ho
 4. `$HOME/.env.{SHELL}.local`
 
 {% hint style="info" %}
-_**{SHELL}**_ will be **zsh**, **bash**, **fish**, etc. depending on the shell you are using.&#x20;
+_**{SHELL}**_ will be **zsh**, **bash**, **fish**, etc. depending on the
+shell you are using.&#x20;
 {% endhint %}
 
-PMS Loads .env files in this order to allow you different configuration options. These files are where you will overwrite environment variables defined by [plugins](plugins/) to modify behavior.
+PMS loads .env files in this order to allow you different configuration
+options. These files are where you will overwrite environment variables
+defined by [plugins](plugins/) to modify behavior.
 
-<table><thead><tr><th width="223">Environment Variable</th><th>Description</th></tr></thead><tbody><tr><td><code>PMS</code></td><td>Directory where PMS is installed</td></tr><tr><td><code>PMS_LOCAL</code></td><td>Directory where local files are stored</td></tr><tr><td><code>PMS_DEBUG</code></td><td>0 = disabled, 1 = enabled. Enabling debug will produce debug messages</td></tr><tr><td><code>PMS_REPO</code></td><td></td></tr><tr><td><code>PMS_REMOTE</code></td><td></td></tr><tr><td><code>PMS_BRANCH</code></td><td></td></tr><tr><td><code>PMS_THEME</code></td><td></td></tr><tr><td><code>PMS_PLUGINS</code></td><td></td></tr></tbody></table>
+| Environment Variable | Description |
+| --- | --- |
+| `PMS` | Directory where PMS is installed |
+| `PMS_LOCAL` | Directory where local files are stored |
+| `PMS_DEBUG` | 0 = disabled, 1 = enabled. Enables debug messages when set |
+| `PMS_REPO` | GitHub repo for PMS (see [install.sh](../scripts/install.sh)) |
+| `PMS_REMOTE` | Full Git remote URL (see [install.sh](../scripts/install.sh)) |
+| `PMS_BRANCH` | Branch to check out (see [install.sh](../scripts/install.sh)) |
+| `PMS_THEME` | Active theme name (loaded in [lib/core.sh](../lib/core.sh)) |
+| `PMS_PLUGINS` | Space-separated plugin list (used by [pms.sh](../pms.sh)) |
+
+## Overriding defaults
+
+To override any default, add the variable to one of the supported `.env`
+files. For example:
+
+```sh
+# ~/.env.local
+PMS_REPO=myfork/pms
+PMS_REMOTE=https://git.example.com/${PMS_REPO}.git
+PMS_BRANCH=development
+PMS_THEME=solarized
+PMS_PLUGINS=(git docker)
+```
+
+Shell-specific overrides such as `.env.zsh.local` take precedence over
+the more general files.


### PR DESCRIPTION
## Summary
- document PMS_REPO, PMS_REMOTE, PMS_BRANCH, PMS_THEME, and PMS_PLUGINS
- show how to override defaults in .env files

## Testing
- `npx -y markdownlint-cli@0.37.0 docs/environment-variables.md` *(fails: MD025 due to multiple top-level headings)*

------
https://chatgpt.com/codex/tasks/task_e_68a51b77aa40832cbfc4e456f47b66ad