### PR TITLE
feat: manage global gitignore in git plugin

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -1,0 +1,32 @@
+# Git
+
+## Aliases
+
+| Alias | Command | Description |
+|-------|---------|-------------|
+| `g`   | `git`   | Shorter alias for `git`. |
+| `gd`  | `git d` | Runs `git d`. |
+| `gs`  | `git s` | Runs `git s`. |
+| `gr`  | `git r` | Runs `git r`. |
+
+## Global Git Ignore
+
+The plugin maintains a user-level global gitignore file at
+`$HOME/.config/git/ignore`. The file can be changed by setting the
+`GIT_GLOBAL_IGNORE_FILE` environment variable before loading the plugin.
+
+On activation the plugin configures `core.excludesFile` to point to this
+file if it is not already set.
+
+### Updating
+
+Use the `git_global_ignore_update` command to replace the current contents
+with templates from [github/gitignore](https://github.com/github/gitignore):
+
+```sh
+git_global_ignore_update macOS Emacs
+```
+
+Multiple template names may be supplied. An alias `ggiu` is also
+available.
+

--- a/plugins/git/git.plugin.sh
+++ b/plugins/git/git.plugin.sh
@@ -1,3 +1,5 @@
+# vim: set ft=sh:
+# shellcheck shell=sh
 ####
 # Plugin: git
 ####
@@ -6,5 +8,37 @@ alias gd='git d'
 alias gs='git s'
 alias gr='git r'
 
-# @todo manage global excludes file and keep it updated
-# @see https://github.com/github/gitignore
+git_global_ignore_file="${GIT_GLOBAL_IGNORE_FILE:-$HOME/.config/git/ignore}"
+
+git_setup_global_ignore() {
+    mkdir -p "$(dirname "$git_global_ignore_file")"
+    touch "$git_global_ignore_file"
+
+    current_excludes_file="$(git config --global core.excludesFile 2>/dev/null || true)"
+    if [ "$current_excludes_file" != "$git_global_ignore_file" ]; then
+        git config --global core.excludesFile "$git_global_ignore_file"
+    fi
+}
+
+git_global_ignore_update() {
+    if [ "$#" -eq 0 ]; then
+        printf '%s\n' "Usage: git_global_ignore_update <Template> [Template...]" >&2
+        return 1
+    fi
+
+    git_setup_global_ignore || return 1
+    : >"$git_global_ignore_file"
+
+    for template in "$@"; do
+        url="https://raw.githubusercontent.com/github/gitignore/main/Global/${template}.gitignore"
+        if ! curl -fsSL "$url" >>"$git_global_ignore_file"; then
+            printf '%s\n' "Failed to download template: $template" >&2
+            return 1
+        fi
+        printf '\n' >>"$git_global_ignore_file"
+    done
+}
+
+alias ggiu='git_global_ignore_update'
+
+git_setup_global_ignore


### PR DESCRIPTION
## Summary
- add functions to maintain a user-level global gitignore file
- provide update command to fetch GitHub gitignore templates
- document git plugin usage and global ignore management

## Testing
- `shellcheck plugins/git/git.plugin.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a51b7f717c832c8ebb2d7593b1c80b