### PR TITLE
Add Bats tests and CI integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,5 +18,13 @@ jobs:
       - uses: actions/checkout@v2
       - run: sh ./scripts/install.sh
       - run: cat /etc/shells
+      - name: Install Bats (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Install Bats (macOS)
+        if: runner.os == 'macOS'
+        run: brew install bats-core
+      - name: Run unit tests
+        run: bats tests
       - run: source ~/.pms/pms.sh bash 1 && pms help && pms diagnostic && pms about && pms theme list && pms plugin list
       - run: sh ~/.pms/scripts/uninstall.sh -n

--- a/README.md
+++ b/README.md
@@ -107,3 +107,14 @@ really cool shit with git.
 
 * [User Guides](https://docs.codewithjoshua.com/pms)
 * [Developer Guides](https://docs.codewithjoshua.com/pms)
+
+# Tests
+
+PMS uses [Bats](https://bats-core.readthedocs.io/) for unit tests. After
+installing Bats with your package manager (for example, `sudo apt-get install
+bats` or `brew install bats-core`), run all tests with:
+
+```
+bats tests
+```
+

--- a/tests/plugin_load_missing.bats
+++ b/tests/plugin_load_missing.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    # shellcheck disable=SC2034
+    color_blue=""
+    # shellcheck disable=SC2034
+    color_red=""
+    # shellcheck disable=SC2034
+    color_green=""
+    # shellcheck disable=SC2034
+    color_yellow=""
+    # shellcheck disable=SC2034
+    color_reset=""
+    # shellcheck source=../lib/core.sh disable=SC1091
+    source "$PMS/lib/core.sh"
+}
+
+@test "_pms_plugin_load reports missing plugins" {
+    run _pms_plugin_load "missing"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Plugin 'missing' could not be loaded"* ]]
+}
+

--- a/tests/theme_load_default.bats
+++ b/tests/theme_load_default.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/themes"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    # shellcheck disable=SC2034
+    color_blue=""
+    # shellcheck disable=SC2034
+    color_red=""
+    # shellcheck disable=SC2034
+    color_green=""
+    # shellcheck disable=SC2034
+    color_yellow=""
+    # shellcheck disable=SC2034
+    color_reset=""
+    # shellcheck source=../lib/core.sh disable=SC1091
+    source "$PMS/lib/core.sh"
+}
+
+@test "_pms_theme_load loads default theme" {
+    PMS_THEME="default"
+    run _pms_theme_load "$PMS_THEME"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[theme] Loading 'default' theme"* ]]
+}
+


### PR DESCRIPTION
## Summary
- add initial Bats tests for `_pms_theme_load` and `_pms_plugin_load`
- run new tests in CI via GitHub Actions
- document how to run the test suite locally

## Testing
- `shellcheck tests/theme_load_default.bats tests/plugin_load_missing.bats`
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_68a51b8d4400832c87ba1fd53c702656