### PR TITLE
feat: add plugin search and install commands

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -5,4 +5,25 @@ classes: wide
 
 # Plugins
 
-Plugins will contain things such as Commands, Functions, Aliases, Auto Completion Scripts, and more. Plugins are focused on enhancing your experience in the shell.
+Plugins will contain things such as Commands, Functions, Aliases, Auto Completion Scripts, and more.
+Plugins are focused on enhancing your experience in the shell.
+
+## Searching for Plugins
+
+Use the plugin index to find new plugins:
+
+```sh
+pms plugin search <term>
+```
+
+Omit `<term>` to list all indexed plugins.
+
+## Installing Plugins
+
+Install a plugin directly from a Git repository:
+
+```sh
+pms plugin install https://example.com/your/plugin.git
+```
+
+The repository is cloned into your local PMS plugins directory and enabled automatically.


### PR DESCRIPTION
## Summary
- add `pms plugin search` to query remote plugin index
- add `pms plugin install` to clone repo into local plugins and enable it
- document plugin search and install usage

## Testing
- `shellcheck lib/cli.sh`
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_68a531cfa560832ca8a69e2ff817f3b9