### PR TITLE
feat: support plugin index

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -33,6 +33,7 @@ defined by [plugins](plugins/) to modify behavior.
 | `PMS_BRANCH` | Branch to check out (see [install.sh](../scripts/install.sh)) |
 | `PMS_THEME` | Active theme name (loaded in [lib/core.sh](../lib/core.sh)) |
 | `PMS_PLUGINS` | Space-separated plugin list (used by [pms.sh](../pms.sh)) |
+| `PMS_PLUGIN_INDEX` | File path or URL for plugin search and install index |
 
 ## Overriding defaults
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -10,6 +10,10 @@ Plugins are focused on enhancing your experience in the shell.
 
 ## Searching for Plugins
 
+Plugins are listed in an index defined by `PMS_PLUGIN_INDEX`. By default this
+uses the `plugins.txt` file in the PMS installation directory. Each line is
+formatted as `code|name|description|repo`.
+
 Use the plugin index to find new plugins:
 
 ```sh
@@ -20,7 +24,13 @@ Omit `<term>` to list all indexed plugins.
 
 ## Installing Plugins
 
-Install a plugin directly from a Git repository:
+Install a plugin using its code from the index:
+
+```sh
+pms plugin install example
+```
+
+You can also install directly from a Git repository:
 
 ```sh
 pms plugin install https://example.com/your/plugin.git

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,0 +1,5 @@
+# code|name|description|repo
+example|Example Plugin|Sample plugin demonstrating structure|https://github.com/JoshuaEstes/pms-example-plugin.git
+taskwarrior|Taskwarrior|Integrates Taskwarrior task manager|https://github.com/JoshuaEstes/pms-taskwarrior-plugin.git
+tmux|Tmux|Adds tmux enhancements|https://github.com/JoshuaEstes/pms-tmux-plugin.git
+

--- a/tests/plugin_install_code.bats
+++ b/tests/plugin_install_code.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    color_blue=""
+    color_red=""
+    color_green=""
+    color_yellow=""
+    color_reset=""
+    source "$PMS/lib/core.sh"
+    source "$PMS/lib/cli.sh"
+}
+
+@test "plugin install uses code from index" {
+    plugin_repo="$BATS_TEST_TMPDIR/sample-plugin"
+    mkdir "$plugin_repo"
+    git init "$plugin_repo" >/dev/null
+    touch "$plugin_repo/sample.plugin.sh"
+    git -C "$plugin_repo" add sample.plugin.sh >/dev/null
+    git -C "$plugin_repo" commit -m 'init' >/dev/null
+
+    echo "sample|Sample Plugin|Test plugin|$plugin_repo" > "$BATS_TEST_TMPDIR/index.txt"
+    export PMS_PLUGIN_INDEX="$BATS_TEST_TMPDIR/index.txt"
+
+    run __pms_command_plugin_install sample
+    [ "$status" -eq 0 ]
+    [ -d "$PMS_LOCAL/plugins/sample" ]
+}
+

--- a/tests/plugin_search.bats
+++ b/tests/plugin_search.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    color_blue=""
+    color_red=""
+    color_green=""
+    color_yellow=""
+    color_reset=""
+    source "$PMS/lib/core.sh"
+    source "$PMS/lib/cli.sh"
+}
+
+@test "plugin search shows code and repository" {
+    run __pms_command_plugin_search example
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"example"* ]]
+    [[ "$output" == *"Example Plugin"* ]]
+    [[ "$output" == *"pms-example-plugin.git"* ]]
+}
+


### PR DESCRIPTION
## Summary
- add local `plugins.txt` index with codes, names, descriptions and repos
- allow `pms plugin install` to resolve plugin code via `PMS_PLUGIN_INDEX`
- document `PMS_PLUGIN_INDEX` and plugin index usage

## Testing
- `shellcheck lib/cli.sh | tail -n 20`
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_68a535965ca8832c96d0407dfd338efe