### PR TITLE
Measure plugin load times

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
 * [Environment Variables](environment-variables.md)
 * [Upgrade PMS](upgrade.md)
 * [PMS Manager](pms-manager.md)
+* [Profiling Startup Times](startup-profiling.md)
 * [Plugins](plugins/README.md)
   * [cd](plugins/cd.md)
   * [composer](plugins/composer.md)

--- a/docs/startup-profiling.md
+++ b/docs/startup-profiling.md
@@ -1,0 +1,21 @@
+---
+title: Profiling Startup Times
+---
+
+# Profiling Startup Times
+
+PMS measures how long each plugin takes to load. These timings are collected during startup and can be viewed with the diagnostic command.
+
+## Viewing Timings
+
+Run the diagnostic command after PMS has loaded:
+
+```
+pms diagnostic
+```
+
+The output includes a **Plugin Timings** section listing each plugin and the time in milliseconds required to load it.
+
+## Interpreting Results
+
+Plugins that take significantly longer than others may slow down your shell's startup time. Consider disabling or optimizing those plugins if performance becomes an issue.

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -1,4 +1,5 @@
 # vim: set ft=sh:
+# shellcheck shell=bash
 ####
 # This file contains the PMS script that manages everything
 #
@@ -151,6 +152,14 @@ __pms_command_diagnostic() {
     echo "PMS_DOTFILES_REMOTE  : $PMS_DOTFILES_REMOTE"
     echo "PMS_DOTFILES_BRANCH  : $PMS_DOTFILES_BRANCH"
     echo "PMS_DOTFILES_GIT_DIR : $PMS_DOTFILES_GIT_DIR"
+    if [ "${#PMS_PLUGIN_TIME_NAMES[@]}" -gt 0 ]; then
+        echo
+        echo "-=[ Plugin Timings ]=-"
+        local timing_index
+        for timing_index in "${!PMS_PLUGIN_TIME_NAMES[@]}"; do
+            printf "%-20s : %s ms\n" "${PMS_PLUGIN_TIME_NAMES[$timing_index]}" "${PMS_PLUGIN_TIME_VALUES[$timing_index]}"
+        done
+    fi
     if [ -d $PMS ]; then
         echo "Hash                 : $(cd $PMS; git rev-parse --short HEAD)"
     else
@@ -730,7 +739,7 @@ __pms_command_plugin_enable() {
     fi
 
     _pms_message "info" "Loading plugin"
-    _pms_plugin_load "$plugin"
+    _pms_time "$plugin" _pms_plugin_load "$plugin"
 
   return 0
 }

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -59,6 +59,32 @@ _pms_source_file() {
     fi
 }
 
+PMS_PLUGIN_TIME_NAMES=()
+PMS_PLUGIN_TIME_VALUES=()
+
+_pms_now() {
+    local now
+    if now=$(date +%s%3N 2>/dev/null); then
+        printf '%s\n' "$now"
+    else
+        printf '%s000\n' "$(date +%s)"
+    fi
+}
+
+_pms_time() {
+    local timing_label=$1
+    shift
+    local start_time end_time elapsed_time exit_code
+    start_time=$(_pms_now)
+    "$@"
+    exit_code=$?
+    end_time=$(_pms_now)
+    elapsed_time=$(( end_time - start_time ))
+    PMS_PLUGIN_TIME_NAMES+=("$timing_label")
+    PMS_PLUGIN_TIME_VALUES+=("$elapsed_time")
+    return $exit_code
+}
+
 ####
 # Loads the theme files
 #

--- a/pms.sh
+++ b/pms.sh
@@ -52,7 +52,8 @@ _pms_source_file "$HOME/.pms.plugins"
 _pms_source_file "$HOME/.pms.theme"
 
 # Load the PMS and SHELL plugins
-_pms_plugin_load pms $PMS_SHELL
+_pms_time "pms" _pms_plugin_load pms
+_pms_time "$PMS_SHELL" _pms_plugin_load "$PMS_SHELL"
 
 if [ "${PMS_DEBUG:-0}" -eq 1 ]; then
     # If debug is enabled, we want to see the current settings at this point
@@ -79,7 +80,7 @@ fi
 ####
 for plugin in ${PMS_PLUGINS[@]}; do
     if [[ "$plugin" != "$PMS_SHELL" && "$plugin" != "pms" ]]; then
-        _pms_plugin_load "$plugin"
+        _pms_time "$plugin" _pms_plugin_load "$plugin"
     fi
 done
 unset plugin

--- a/tests/plugin_load_timing.bats
+++ b/tests/plugin_load_timing.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins/sample"
+    touch "$PMS_LOCAL/plugins/sample/sample.plugin.sh"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    # shellcheck disable=SC2034
+    color_blue=""
+    # shellcheck disable=SC2034
+    color_red=""
+    # shellcheck disable=SC2034
+    color_green=""
+    # shellcheck disable=SC2034
+    color_yellow=""
+    # shellcheck disable=SC2034
+    color_reset=""
+    # shellcheck source=../lib/core.sh disable=SC1091
+    source "$PMS/lib/core.sh"
+    # shellcheck source=../lib/cli.sh disable=SC1091
+    source "$PMS/lib/cli.sh"
+}
+
+@test "_pms_time records plugin load duration" {
+    _pms_time "sample" _pms_plugin_load sample
+    [ "${PMS_PLUGIN_TIME_NAMES[0]}" = "sample" ]
+    [[ "${PMS_PLUGIN_TIME_VALUES[0]}" -ge 0 ]]
+}
+
+@test "__pms_command_diagnostic shows plugin timings" {
+    _pms_time "sample" _pms_plugin_load sample
+    run __pms_command_diagnostic
+    [[ "$output" == *"sample"* ]]
+}


### PR DESCRIPTION
## Summary
- add `_pms_time` helper to measure and record plugin load durations
- wrap plugin loads with `_pms_time` and surface per-plugin timings in `pms diagnostic`
- document how to profile startup times and add tests for timing support

## Testing
- `shellcheck pms.sh lib/core.sh lib/cli.sh tests/plugin_load_timing.bats`
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_68a5389339c4832cace5aa12322b513d