### PR TITLE
Initialize zsh completions with caching

### DIFF
--- a/plugins/zsh/zsh.plugin.zsh
+++ b/plugins/zsh/zsh.plugin.zsh
@@ -1,4 +1,5 @@
 # vim: set ft=zsh:
+# shellcheck shell=sh
 # Perform implicit tees or cats when multiple redirections are attempted
 setopt multios
 
@@ -9,3 +10,11 @@ setopt prompt_subst
 
 # Completions
 autoload -U compaudit compinit
+
+completion_dump="${PMS_CACHE_DIR}/zcompdump"
+if compaudit >/dev/null 2>&1; then
+    mkdir -p "${PMS_CACHE_DIR}"
+    compinit -d "${completion_dump}"
+else
+    printf 'pms: insecure completion directories detected, skipping compinit\n' >&2
+fi

--- a/tests/zsh_compinit.bats
+++ b/tests/zsh_compinit.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_CACHE_DIR="$BATS_TEST_TMPDIR/cache"
+    mkdir -p "$PMS_CACHE_DIR"
+}
+
+@test "zsh plugin initializes completions" {
+    run zsh -c "source \"$PMS/plugins/zsh/zsh.plugin.zsh\""
+    [ "$status" -eq 0 ]
+    [ -f "$PMS_CACHE_DIR/zcompdump" ]
+}


### PR DESCRIPTION
## Summary
- initialize zsh completions using compaudit and compinit with cached dump
- warn and skip initialization when insecure completion directories are detected
- add a unit test to ensure zsh plugin runs compinit

## Testing
- `shellcheck plugins/zsh/zsh.plugin.zsh tests/zsh_compinit.bats`
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_68a53968a178832cb01d0fb30787501b