### PR TITLE
feat: load project configuration

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -10,10 +10,25 @@ title: PMS Features
 * Multiple Shell Support
   * No matter the shell, you can easily swap between them and maintain similar functionality
 * PMS Manager
-  * Easy upgrade PMS
+  * Easily upgrade PMS
   * Preview and switch themes
-  * Easy Plugin enabled and disable
+  * Easily enable and disable plugins
   * Helps manage dotfiles
 * Focus on using environment variables to modify functionality of PMS
 * Easy to extend and overwrite any file, even the PMS core
-* Easy Uninstall
+* Project configuration with `.pms` files
+* Easy uninstall
+
+## Project configuration files
+
+Projects can include a `.pms` file in their directory tree. PMS searches the
+current directory and each parent directory for this file during startup. If
+found, the file is sourced and can override user defaults.
+
+The file is plain shell script and supports variables such as `PMS_PLUGINS` and
+`PMS_THEME`.
+
+```sh
+PMS_THEME=solarized
+PMS_PLUGINS=(git docker)
+```

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -59,6 +59,32 @@ _pms_source_file() {
     fi
 }
 
+####
+# Search upwards for a '.pms' file and source it
+#
+# Usage: _pms_project_file_load
+#
+# The project file may define variables like PMS_PLUGINS and PMS_THEME
+# to override user defaults for a given directory tree.
+#
+# @internal
+####
+_pms_project_file_load() {
+    local search_dir project_file
+    search_dir="$PWD"
+    while [ "$search_dir" != "/" ]; do
+        project_file="$search_dir/.pms"
+        if [ -f "$project_file" ]; then
+            _pms_message_section "info" "project" "Loading '$project_file'"
+            # shellcheck source=/dev/null
+            source "$project_file"
+            return 0
+        fi
+        search_dir="$(dirname "$search_dir")"
+    done
+    return 1
+}
+
 PMS_PLUGIN_TIME_NAMES=()
 PMS_PLUGIN_TIME_VALUES=()
 

--- a/pms.sh
+++ b/pms.sh
@@ -3,6 +3,7 @@
 #
 # This is the main entry point for PMS.
 ####
+# shellcheck shell=bash
 
 # Validate we can properly configure the shell
 # @todo Ensure that its a supported shell
@@ -51,6 +52,9 @@ unset lib
 _pms_source_file "$HOME/.pms.plugins"
 _pms_source_file "$HOME/.pms.theme"
 
+# Load project configuration if present
+_pms_project_file_load
+
 # Load the PMS and SHELL plugins
 _pms_time "pms" _pms_plugin_load pms
 _pms_time "$PMS_SHELL" _pms_plugin_load "$PMS_SHELL"
@@ -78,7 +82,7 @@ fi
 ####
 # Load all enabled plugins
 ####
-for plugin in ${PMS_PLUGINS[@]}; do
+for plugin in "${PMS_PLUGINS[@]}"; do
     if [[ "$plugin" != "$PMS_SHELL" && "$plugin" != "pms" ]]; then
         _pms_time "$plugin" _pms_plugin_load "$plugin"
     fi
@@ -89,5 +93,5 @@ unset plugin
 ####
 # Load Theme
 ####
-_pms_theme_load $PMS_THEME
+_pms_theme_load "$PMS_THEME"
 ####

--- a/tests/project_file.bats
+++ b/tests/project_file.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    # shellcheck disable=SC2034
+    color_blue=""
+    # shellcheck disable=SC2034
+    color_red=""
+    # shellcheck disable=SC2034
+    color_green=""
+    # shellcheck disable=SC2034
+    color_yellow=""
+    # shellcheck disable=SC2034
+    color_reset=""
+    # shellcheck source=../lib/core.sh disable=SC1091
+    source "$PMS/lib/core.sh"
+}
+
+@test "_pms_project_file_load loads current directory project file" {
+    project_dir="$BATS_TEST_TMPDIR/project"
+    mkdir -p "$project_dir"
+    cat <<'EOP' > "$project_dir/.pms"
+PMS_PLUGINS=(git docker)
+PMS_THEME=monokai
+EOP
+    pushd "$project_dir" >/dev/null
+    PMS_PLUGINS=()
+    PMS_THEME=""
+    _pms_project_file_load
+    status=$?
+    [ "$status" -eq 0 ]
+    [[ "${PMS_PLUGINS[*]}" = "git docker" ]]
+    [ "$PMS_THEME" = "monokai" ]
+    popd >/dev/null
+}
+
+@test "_pms_project_file_load searches parent directories" {
+    parent="$BATS_TEST_TMPDIR/parent"
+    mkdir -p "$parent/sub"
+    cat <<'EOP' > "$parent/.pms"
+PMS_THEME=solarized
+EOP
+    pushd "$parent/sub" >/dev/null
+    PMS_THEME=""
+    _pms_project_file_load
+    status=$?
+    [ "$status" -eq 0 ]
+    [ "$PMS_THEME" = "solarized" ]
+    popd >/dev/null
+}
+
+@test "_pms_project_file_load returns failure when no project file" {
+    empty_dir="$BATS_TEST_TMPDIR/empty"
+    mkdir -p "$empty_dir"
+    pushd "$empty_dir" >/dev/null
+    status=0
+    _pms_project_file_load || status=$?
+    [ "$status" -eq 1 ]
+    popd >/dev/null
+}


### PR DESCRIPTION
## Summary
- load nearest `.pms` project file during startup
- document project configuration format and usage
- test project file discovery and config overrides

## Testing
- `shellcheck lib/core.sh pms.sh tests/project_file.bats`
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_68a53b35d82c832c990b10145d897e7d