### PR TITLE
feat(zsh): add history environment defaults

### DIFF
--- a/plugins/zsh/env
+++ b/plugins/zsh/env
@@ -12,3 +12,15 @@ DIRSTACKSIZE=${DIRSTACKSIZE:-10}
 
 # Key binding timeout in tenths of a second
 KEYTIMEOUT=${KEYTIMEOUT:-1}
+
+# Number of commands stored in memory
+HISTSIZE=${HISTSIZE:-10000}
+
+# Number of history entries saved to file
+SAVEHIST=${SAVEHIST:-10000}
+
+# Location of the history file
+HISTFILE=${HISTFILE:-"$HOME/.zsh_history"}
+
+# Ignore commands that duplicate earlier ones in history
+HIST_IGNORE_ALL_DUPS=${HIST_IGNORE_ALL_DUPS:-1}

--- a/tests/zsh_history_defaults.bats
+++ b/tests/zsh_history_defaults.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+}
+
+@test "HISTSIZE defaults to 10000" {
+    run zsh -c "unset HISTSIZE; source \"$PMS/plugins/zsh/env\"; printf '%s\n' \"\$HISTSIZE\""
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" -eq 10000 ]
+}
+
+@test "SAVEHIST defaults to 10000" {
+    run zsh -c "unset SAVEHIST; source \"$PMS/plugins/zsh/env\"; printf '%s\n' \"\$SAVEHIST\""
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" -eq 10000 ]
+}
+
+@test "HISTFILE defaults to \$HOME/.zsh_history" {
+    run zsh -c "unset HISTFILE; export HOME=\"$BATS_TEST_TMPDIR\"; source \"$PMS/plugins/zsh/env\"; printf '%s\n' \"\$HISTFILE\""
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "$BATS_TEST_TMPDIR/.zsh_history" ]
+}
+
+@test "HIST_IGNORE_ALL_DUPS defaults to 1" {
+    run zsh -c "unset HIST_IGNORE_ALL_DUPS; source \"$PMS/plugins/zsh/env\"; printf '%s\n' \"\$HIST_IGNORE_ALL_DUPS\""
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" -eq 1 ]
+}


### PR DESCRIPTION
## Summary
- set zsh history defaults with user overrides
- test zsh history environment variable defaults

## Testing
- `shellcheck plugins/zsh/env tests/zsh_history_defaults.bats`
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_68a53bb004f0832cb92440c98147c48f