### PR TITLE
feat(zsh): show git status in default theme

### DIFF
--- a/tests/theme_vcs_info_prompt.bats
+++ b/tests/theme_vcs_info_prompt.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+# shellcheck disable=SC2016
+@test "default zsh theme includes vcs_info in PROMPT" {
+    run env PMS="$(cd "$BATS_TEST_DIRNAME/.." && pwd)" zsh -c '
+        source "$PMS/themes/default/default.theme.zsh"
+        echo "$PROMPT"
+    '
+    [ "$status" -eq 0 ]
+    [[ "${lines[0]}" == *"vcs_info_msg_0_"* ]]
+}
+

--- a/themes/default/README.md
+++ b/themes/default/README.md
@@ -1,1 +1,5 @@
 Default Theme
+
+The Zsh variant of this theme now initializes `vcs_info` and uses color
+definitions from `lib/colors.zsh` to display Git status information in the
+prompt. The Bash theme remains unchanged.

--- a/themes/default/default.theme.zsh
+++ b/themes/default/default.theme.zsh
@@ -1,3 +1,24 @@
-#@ see http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Prompt-Expansion
+# @see http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html#Prompt-Expansion
 # joshua@host.dev ~/path %
-PROMPT="%n@%M %~ %# "
+
+# shellcheck shell=bash disable=SC1090,SC2034,SC2154,SC1087
+# Load color definitions for readable prompt segments.
+# shellcheck source=lib/colors.zsh
+source "$PMS/lib/colors.zsh"
+
+# Initialize version control information to display Git status.
+autoload -Uz vcs_info
+precmd() {
+    vcs_info
+}
+
+# Configure vcs_info for Git repositories.
+zstyle ':vcs_info:*' enable git
+zstyle ':vcs_info:git:*' check-for-changes true
+zstyle ':vcs_info:git:*' unstagedstr '%F{red}*%f'
+zstyle ':vcs_info:git:*' stagedstr '%F{green}+%f'
+zstyle ':vcs_info:git:*' formats '%F{yellow}[%b%u%c]%f'
+zstyle ':vcs_info:git:*' actionformats '%F{yellow}[%b|%a]%f'
+
+# Display user, host, working directory and Git status.
+PROMPT="%{$fg[green]%}%n%{$reset_color%}@%{$fg[blue]%}%M %{$fg[cyan]%}%~%{$reset_color%} \${vcs_info_msg_0_} %# "


### PR DESCRIPTION
## Summary
- integrate `vcs_info` into default Zsh theme and display Git branch/state
- use shared color definitions for clearer prompt styling
- document Zsh prompt features and add test for `vcs_info` prompt output

## Testing
- `shellcheck -x themes/default/default.theme.zsh tests/theme_vcs_info_prompt.bats`
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_68a53e2ba824832caf2baa1a8806fab4