### PR TITLE
feat: add dotfiles plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ power of PMS ;)
   * Shell Options, Auto Completions, Commands, and more are just some of the
     things plugins can provide.
 * Dotfiles
-  * Get help managing those dotfiles! No more custom install or update scripts
+  * Managed through a dedicated plugin
   * Your dotfiles are backed up to your own git repository
 * Multiple Shell Support (Bash, Zsh, etc.)
   * Works to load sane defaults for you (with the help of various plugins)

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ supports easy install/uninstall and a wide variety of plugins and themes.
 
 * [Themes](themes/) - Change the way your environment looks
 * [Plugins](plugins/) - Change the way your environment functions
-* Dotfiles - Change the way programs work in your environment
+* Dotfiles - Manage configuration files through a plugin-backed git repository
 * Multiple Shell Support
   * No matter the shell, you can easily swap between them and maintain similar functionality
 * [PMS Manager](pms-manager.md) - Easy to use and up modify tool to help you manage PMS

--- a/docs/features.md
+++ b/docs/features.md
@@ -6,7 +6,7 @@ title: PMS Features
 
 * [Themes](themes/)
 * [Plugins](plugins/)
-* Dotfiles Management
+* Dotfiles Plugin for managing configuration files
 * Multiple Shell Support
   * No matter the shell, you can easily swap between them and maintain similar functionality
 * PMS Manager

--- a/docs/pms-manager.md
+++ b/docs/pms-manager.md
@@ -62,7 +62,7 @@ pms theme switch [THEME]
 
 ## Managing your Dotfiles
 
-Dotfiles are a very important part of being a developer and most like to make sure those files are backed up. The PMS Manager supports managing your dotfiles using git.
+Dotfile management is provided by the `dotfiles` plugin, which is enabled by default. Dotfiles are a very important part of being a developer and most like to make sure those files are backed up. The PMS Manager supports managing your dotfiles using git.
 
 The repository that will be managed will look something like [this](https://github.com/JoshuaEstes/dotfiles)
 

--- a/plugins/dotfiles/README.md
+++ b/plugins/dotfiles/README.md
@@ -1,0 +1,3 @@
+# Dotfiles Plugin
+
+Provides PMS commands for managing your dotfiles with a git repository.

--- a/plugins/dotfiles/dotfiles.plugin.bash
+++ b/plugins/dotfiles/dotfiles.plugin.bash
@@ -1,0 +1,4 @@
+# vim: set ft=sh:
+# shellcheck shell=sh
+# Bash-specific hooks for the dotfiles plugin
+# Currently no bash specific behaviour

--- a/plugins/dotfiles/dotfiles.plugin.sh
+++ b/plugins/dotfiles/dotfiles.plugin.sh
@@ -1,0 +1,68 @@
+# vim: set ft=sh:
+# shellcheck shell=bash
+####
+# Dotfiles Plugin
+#
+# Provides commands for managing user dotfiles via a git repository.
+####
+
+# Dispatch dotfiles subcommands
+__pms_command_dotfiles() {
+    [[ $# -gt 0 ]] || {
+        __pms_command_help_dotfiles
+        return 1
+    }
+
+    local subcommand="$1"
+    shift
+
+    type "__pms_command_dotfiles_${subcommand}" >/dev/null 2>&1 && {
+        "__pms_command_dotfiles_${subcommand}" "$@"
+        return $?
+    }
+
+    __pms_command_help_dotfiles
+    return 1
+}
+
+# Display help information for dotfiles commands
+__pms_command_help_dotfiles() {
+    echo
+    echo "Usage: pms [options] dotfiles <command>"
+    echo
+    echo "Commands:"
+    __pms_command "push" "Push changes"
+    __pms_command "add [file] [file] ..." "Add file(s) to your repository (commit and push)"
+    __pms_command "git <command>" "Runs the git command (example: pms dotfiles git status)"
+    echo
+    return 0
+}
+
+# Pushes committed dotfiles to the remote repository
+__pms_command_dotfiles_push() {
+    git --git-dir="$PMS_DOTFILES_GIT_DIR" --work-tree="$HOME" -C "$HOME" push origin "$PMS_DOTFILES_BRANCH"
+}
+
+# Adds and commits dotfiles
+__pms_command_dotfiles_add() {
+    local tracked_files=( "$@" )
+    if [ $# -eq 0 ]; then
+        # shellcheck disable=SC2207
+        tracked_files=( $(git --git-dir="$PMS_DOTFILES_GIT_DIR" --work-tree="$HOME" -C "$HOME" diff --name-only --diff-filter=MD) )
+    fi
+    if [ "${#tracked_files[@]}" -eq 0 ]; then
+        _pms_message "error" "Nothing to do"
+        return 1
+    fi
+    local file
+    for file in "${tracked_files[@]}"; do
+        git --git-dir="$PMS_DOTFILES_GIT_DIR" --work-tree="$HOME" -C "$HOME" add --verbose --force "$file"
+    done
+    git --git-dir="$PMS_DOTFILES_GIT_DIR" --work-tree="$HOME" -C "$HOME" commit -m "Update dotfiles"
+    __pms_command_dotfiles_push
+}
+
+# Runs arbitrary git command within the dotfiles repository
+__pms_command_dotfiles_git() {
+    git --git-dir="$PMS_DOTFILES_GIT_DIR" --work-tree="$HOME" -C "$HOME" "$@"
+}

--- a/plugins/dotfiles/dotfiles.plugin.zsh
+++ b/plugins/dotfiles/dotfiles.plugin.zsh
@@ -1,0 +1,4 @@
+# vim: set ft=sh:
+# shellcheck shell=sh
+# Zsh-specific hooks for the dotfiles plugin
+# Currently no zsh specific behaviour

--- a/plugins/dotfiles/env
+++ b/plugins/dotfiles/env
@@ -1,0 +1,19 @@
+# vim: set ft=sh:
+# shellcheck shell=sh disable=SC2034
+####
+# Dotfiles Plugin Environment
+#
+# Provides default configuration for managing dotfiles with PMS.
+####
+
+# Repository containing your dotfiles
+PMS_DOTFILES_REPO=${PMS_DOTFILES_REPO:-JoshuaEstes/dotfiles}
+
+# Remote URL used to push and pull changes
+PMS_DOTFILES_REMOTE=${PMS_DOTFILES_REMOTE:-git@github.com:${PMS_DOTFILES_REPO}.git}
+
+# Branch used for your dotfiles repository
+PMS_DOTFILES_BRANCH=${PMS_DOTFILES_BRANCH:-main}
+
+# Location of the bare git repository that tracks your dotfiles
+PMS_DOTFILES_GIT_DIR=${PMS_DOTFILES_GIT_DIR:-${HOME}/.dotfiles}

--- a/plugins/dotfiles/install.sh
+++ b/plugins/dotfiles/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+#
+# Installs the dotfiles plugin by initializing the dotfiles repository if needed.
+set -e
+
+if [ ! -d "$PMS_DOTFILES_GIT_DIR" ]; then
+    git init --bare "$PMS_DOTFILES_GIT_DIR"
+    git --git-dir="$PMS_DOTFILES_GIT_DIR" --work-tree="$HOME" -C "$HOME" config --local status.showUntrackedFiles no
+fi

--- a/plugins/dotfiles/uninstall.sh
+++ b/plugins/dotfiles/uninstall.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+#
+# Uninstalls the dotfiles plugin by backing up the dotfiles repository.
+set -e
+
+if [ -d "$PMS_DOTFILES_GIT_DIR" ]; then
+    mv -f "$PMS_DOTFILES_GIT_DIR" "${PMS_DOTFILES_GIT_DIR}.bak"
+fi

--- a/plugins/dotfiles/update.sh
+++ b/plugins/dotfiles/update.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+#
+# Updates the dotfiles repository.
+set -e
+
+git --git-dir="$PMS_DOTFILES_GIT_DIR" --work-tree="$HOME" -C "$HOME" pull origin "$PMS_DOTFILES_BRANCH" >/dev/null 2>&1 || true

--- a/plugins/pms/env
+++ b/plugins/pms/env
@@ -1,4 +1,5 @@
 # vim: set ft=sh:
+# shellcheck shell=sh disable=SC2034
 ####
 # PMS Environment Variables
 #
@@ -37,17 +38,3 @@ PMS_CACHE_DIR=${PMS_CACHE_DIR:-${PMS}/cache}
 # Log directory
 PMS_LOG_DIR=${PMS_LOG_DIR:-${PMS}/log}
 
-###
-# This is the repository that updates will be pushed to
-PMS_DOTFILES_REPO=${PMS_DOTFILES_REPO:-JoshuaEstes/dotfiles}
-PMS_DOTFILES_REMOTE=${PMS_DOTFILES_REMOTE:-git@github.com:${PMS_DOTFILES_REPO}.git}
-
-###
-# What is the branch that we will be using for dotfiles
-PMS_DOTFILES_BRANCH=${PMS_DOTFILES_BRANCH:-main}
-
-###
-# This will be the location where the git repo maintain your dotfiles. Your
-# dotfiles will not be stored here. You will be able to view and edit your
-# dotfiles in your $HOME directory
-PMS_DOTFILES_GIT_DIR=${PMS_DOTFILES_GIT_DIR:-${HOME}/.dotfiles}

--- a/pms.sh
+++ b/pms.sh
@@ -72,11 +72,7 @@ if [ "${PMS_DEBUG:-0}" -eq 1 ]; then
     _pms_message "info"  "PMS_BRANCH           : $PMS_BRANCH"
     _pms_message "info"  "PMS_THEME            : $PMS_THEME"
     _pms_message "info"  "PMS_PLUGINS          : ${PMS_PLUGINS[*]}"
-    _pms_message "info"  "PMS_SHELL            : $PMS_SHELL"
-    _pms_message "info"  "PMS_DOTFILES_REPO    : $PMS_DOTFILES_REPO"
-    _pms_message "info"  "PMS_DOTFILES_REMOTE  : $PMS_DOTFILES_REMOTE"
-    _pms_message "info"  "PMS_DOTFILES_BRANCH  : $PMS_DOTFILES_BRANCH"
-    _pms_message "info"  "PMS_DOTFILES_GIT_DIR : $PMS_DOTFILES_GIT_DIR\n"
+    _pms_message "info"  "PMS_SHELL            : $PMS_SHELL\n"
 fi
 
 ####

--- a/templates/env
+++ b/templates/env
@@ -1,4 +1,5 @@
 # vim: set ft=sh:
+# shellcheck shell=sh disable=SC2034
 ####
 #  _______   __                                __       __                   ______   __                  __  __
 # /       \ /  |                              /  \     /  |                 /      \ /  |                /  |/  |
@@ -51,4 +52,4 @@ PMS_DOTFILES_BRANCH=main
 # This will be the location where the git repo maintain your dotfiles. Your
 # dotfiles will not be stored here. You will be able to view and edit your
 # dotfiles in your $HOME directory
-PMS_DOTFILES_GIT_DIR=${HOME}/.dotfile
+PMS_DOTFILES_GIT_DIR=${HOME}/.dotfiles

--- a/templates/pms.plugins
+++ b/templates/pms.plugins
@@ -1,1 +1,2 @@
-PMS_PLUGINS=(cd history jobs ls mkdir git getting-started)
+# shellcheck shell=bash disable=SC2034
+PMS_PLUGINS=(cd history jobs ls mkdir git dotfiles getting-started)

--- a/tests/dotfiles_command.bats
+++ b/tests/dotfiles_command.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    # shellcheck disable=SC2034
+    color_blue=""
+    # shellcheck disable=SC2034
+    color_red=""
+    # shellcheck disable=SC2034
+    color_green=""
+    # shellcheck disable=SC2034
+    color_yellow=""
+    # shellcheck disable=SC2034
+    color_reset=""
+    # shellcheck source=../lib/core.sh disable=SC1091
+    source "$PMS/lib/core.sh"
+    _pms_plugin_load dotfiles
+    # shellcheck source=../lib/cli.sh disable=SC1091
+    source "$PMS/lib/cli.sh"
+}
+
+@test "dotfiles command shows help without subcommand" {
+    run pms dotfiles
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage: pms [options] dotfiles <command>"* ]]
+}


### PR DESCRIPTION
## Summary
- move dotfiles management into dedicated plugin
- enable dotfiles plugin by default and document usage
- fix template path for dotfiles repo and add plugin tests

## Testing
- `shellcheck lib/cli.sh pms.sh`
- `shellcheck plugins/dotfiles/dotfiles.plugin.sh plugins/dotfiles/dotfiles.plugin.bash plugins/dotfiles/dotfiles.plugin.zsh plugins/dotfiles/install.sh plugins/dotfiles/uninstall.sh plugins/dotfiles/update.sh plugins/dotfiles/env plugins/pms/env templates/env templates/pms.plugins tests/dotfiles_command.bats`
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_68a53e0a4534832cb3d07e1e3407d2e6