### PR TITLE
feat: add interactive plugin and theme selection

### DIFF
--- a/docs/pms-manager.md
+++ b/docs/pms-manager.md
@@ -34,6 +34,9 @@ pms plugin list
 pms plugin enable [PLUGIN]
 ```
 
+When [`fzf`](https://github.com/junegunn/fzf) is installed and no plugin is
+specified, an interactive picker is displayed to help choose a plugin.
+
 ### Disabling Plugins
 
 ```shell
@@ -59,6 +62,9 @@ pms theme list
 ```shell
 pms theme switch [THEME]
 ```
+
+If `fzf` is available and no theme is provided, an interactive picker is shown
+to select the desired theme.
 
 ## Managing your Dotfiles
 

--- a/tests/plugin_enable_interactive.bats
+++ b/tests/plugin_enable_interactive.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    export HOME="$BATS_TEST_TMPDIR"
+    export PMS_PLUGINS=()
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+    cat >"$BATS_TEST_TMPDIR/bin/fzf" <<'FZF'
+#!/usr/bin/env bash
+echo "bash"
+FZF
+    chmod +x "$BATS_TEST_TMPDIR/bin/fzf"
+    # shellcheck disable=SC2034
+    color_blue=""
+    # shellcheck disable=SC2034
+    color_red=""
+    # shellcheck disable=SC2034
+    color_green=""
+    # shellcheck disable=SC2034
+    color_yellow=""
+    # shellcheck disable=SC2034
+    color_reset=""
+    # shellcheck source=../lib/core.sh disable=SC1091
+    source "$PMS/lib/core.sh"
+    # shellcheck source=../lib/cli.sh disable=SC1091
+    source "$PMS/lib/cli.sh"
+}
+
+@test "plugin enable uses fzf when no argument" {
+    __pms_command_plugin_enable
+    [[ "${PMS_PLUGINS[*]}" == *"bash"* ]]
+}

--- a/tests/theme_switch_interactive.bats
+++ b/tests/theme_switch_interactive.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/themes"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    export HOME="$BATS_TEST_TMPDIR"
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+    cat >"$BATS_TEST_TMPDIR/bin/fzf" <<'FZF'
+#!/usr/bin/env bash
+echo "default"
+FZF
+    chmod +x "$BATS_TEST_TMPDIR/bin/fzf"
+    echo "PMS_THEME=joshuaestes" > "$HOME/.pms.theme"
+    PMS_THEME="joshuaestes"
+    # shellcheck disable=SC2034
+    color_blue=""
+    # shellcheck disable=SC2034
+    color_red=""
+    # shellcheck disable=SC2034
+    color_green=""
+    # shellcheck disable=SC2034
+    color_yellow=""
+    # shellcheck disable=SC2034
+    color_reset=""
+    # shellcheck source=../lib/core.sh disable=SC1091
+    source "$PMS/lib/core.sh"
+    # shellcheck source=../lib/cli.sh disable=SC1091
+    source "$PMS/lib/cli.sh"
+}
+
+@test "theme switch uses fzf when no argument" {
+    __pms_command_theme_switch
+    [ "$PMS_THEME" = "default" ]
+    grep -q "PMS_THEME=default" "$HOME/.pms.theme"
+}


### PR DESCRIPTION
## Summary
- detect `fzf` for interactive selections
- allow enabling plugins and switching themes interactively when no argument is given
- document interactive `fzf` support

## Testing
- `shellcheck lib/cli.sh tests/plugin_enable_interactive.bats tests/theme_switch_interactive.bats`
- `bats tests` *(fails: `zsh` command not found in several tests)*
- `bats tests/plugin_enable_interactive.bats tests/theme_switch_interactive.bats`


------
https://chatgpt.com/codex/tasks/task_e_68a5418d2348832c909540b8bf24f4dc