### PR TITLE
Add status and diff commands for dotfiles plugin

### DIFF
--- a/docs/pms-manager.md
+++ b/docs/pms-manager.md
@@ -103,3 +103,19 @@ Adding files is quick, just run `pms dotfiles add FILE` and PMS will add the fil
 ### Pulling down changes
 
 Run `pms dotfiles pull` if you have made any changes in your repository that you want to pull down to your machine.
+
+### Checking repository status
+
+Use `pms dotfiles status` to see which files have been modified in your dotfiles repository.
+
+```shell
+pms dotfiles status
+```
+
+### Viewing changes
+
+To review the exact changes in your files before committing, run:
+
+```shell
+pms dotfiles diff
+```

--- a/plugins/dotfiles/dotfiles.plugin.sh
+++ b/plugins/dotfiles/dotfiles.plugin.sh
@@ -33,6 +33,8 @@ __pms_command_help_dotfiles() {
     echo "Commands:"
     __pms_command "push" "Push changes"
     __pms_command "add [file] [file] ..." "Add file(s) to your repository (commit and push)"
+    __pms_command "status" "Show repository status"
+    __pms_command "diff [file] [file] ..." "Show changes in dotfiles"
     __pms_command "git <command>" "Runs the git command (example: pms dotfiles git status)"
     echo
     return 0
@@ -60,6 +62,16 @@ __pms_command_dotfiles_add() {
     done
     git --git-dir="$PMS_DOTFILES_GIT_DIR" --work-tree="$HOME" -C "$HOME" commit -m "Update dotfiles"
     __pms_command_dotfiles_push
+}
+
+# Shows the status of the dotfiles repository
+__pms_command_dotfiles_status() {
+    git --git-dir="$PMS_DOTFILES_GIT_DIR" --work-tree="$HOME" -C "$HOME" status "$@"
+}
+
+# Displays diff for dotfiles
+__pms_command_dotfiles_diff() {
+    git --git-dir="$PMS_DOTFILES_GIT_DIR" --work-tree="$HOME" -C "$HOME" diff "$@"
 }
 
 # Runs arbitrary git command within the dotfiles repository


### PR DESCRIPTION
## Summary
- add `status` and `diff` subcommands to dotfiles plugin
- document `dotfiles status` and `dotfiles diff` commands
- test status and diff behaviors

## Testing
- `shellcheck plugins/dotfiles/dotfiles.plugin.sh tests/dotfiles_command.bats`
- `bats tests` *(fails: default zsh theme includes vcs_info in PROMPT; zsh plugin initializes completions; HISTSIZE defaults to 10000; SAVEHIST defaults to 10000; HISTFILE defaults to $HOME/.zsh_history; HIST_IGNORE_ALL_DUPS defaults to 1)*
- `bats tests/dotfiles_command.bats`


------
https://chatgpt.com/codex/tasks/task_e_68a541dd8e34832ca7f2b93caced4158