### PR TITLE
Add Kubernetes and AWS plugins

### DIFF
--- a/docs/plugins/aws.md
+++ b/docs/plugins/aws.md
@@ -1,0 +1,39 @@
+---
+title: PMS "aws" Plugin
+toc: true
+pms_plugin: aws
+---
+
+# aws
+
+## Installation
+
+```sh
+pms plugin enable aws
+```
+
+## Requirements
+
+* awscli
+
+## Aliases
+
+| Alias | Command         | Notes                    |
+| ----- | --------------- | ------------------------ |
+| awsp  | aws_set_profile | Sets the AWS_PROFILE var |
+
+## Environment Helpers
+
+The `aws_set_profile` function updates the `AWS_PROFILE` environment variable.
+
+## Prompt Indicators
+
+Use `aws_prompt_profile` to include the active AWS profile in your prompt:
+
+```sh
+PS1='\u@\h \w $(aws_prompt_profile)\$ '
+```
+
+## See Also
+
+* [Plugin Source Code](https://github.com/JoshuaEstes/pms/tree/main/plugins/aws)

--- a/docs/plugins/kubernetes.md
+++ b/docs/plugins/kubernetes.md
@@ -1,0 +1,39 @@
+---
+title: PMS "kubernetes" Plugin
+toc: true
+pms_plugin: kubernetes
+---
+
+# kubernetes
+
+## Installation
+
+```sh
+pms plugin enable kubernetes
+```
+
+## Requirements
+
+* kubectl
+
+## Aliases
+
+| Alias | Command | Notes |
+| ----- | ------- | ----- |
+| k     | kubectl |       |
+
+## Environment Helpers
+
+The `kube_set_default_config` function sets `KUBECONFIG` to `~/.kube/config` if it is unset.
+
+## Prompt Indicators
+
+Use `kube_prompt_context` to show the current Kubernetes context in your prompt:
+
+```sh
+PS1='\u@\h \w $(kube_prompt_context)\$ '
+```
+
+## See Also
+
+* [Plugin Source Code](https://github.com/JoshuaEstes/pms/tree/main/plugins/kubernetes)

--- a/plugins/aws/README.md
+++ b/plugins/aws/README.md
@@ -1,0 +1,3 @@
+# AWS
+
+Adds the `awsp` helper for switching `AWS_PROFILE` values and a prompt helper displaying the active profile.

--- a/plugins/aws/aws.plugin.sh
+++ b/plugins/aws/aws.plugin.sh
@@ -1,0 +1,25 @@
+# vim: set ft=sh:
+# shellcheck shell=sh
+####
+# Plugin: aws
+####
+
+# Sets the AWS_PROFILE environment variable
+aws_set_profile() {
+    if [ "$#" -ne 1 ]; then
+        printf '%s\n' "Usage: aws_set_profile <profile>" >&2
+        return 1
+    fi
+    export AWS_PROFILE="$1"
+}
+
+# Alias for aws_set_profile to quickly switch profiles
+alias awsp='aws_set_profile'
+
+# Displays the current AWS profile for use in prompts
+aws_prompt_profile() {
+    printf '%s' "${AWS_PROFILE:-default}"
+}
+
+# Ensure a profile is always set
+export AWS_PROFILE="${AWS_PROFILE:-default}"

--- a/plugins/kubernetes/README.md
+++ b/plugins/kubernetes/README.md
@@ -1,0 +1,3 @@
+# Kubernetes
+
+Provides a `k` alias for `kubectl` and helper functions for configuring `KUBECONFIG` and displaying the current context.

--- a/plugins/kubernetes/kubernetes.plugin.sh
+++ b/plugins/kubernetes/kubernetes.plugin.sh
@@ -1,0 +1,22 @@
+# vim: set ft=sh:
+# shellcheck shell=sh
+####
+# Plugin: kubernetes
+####
+
+# Alias for kubectl command
+alias k='kubectl'
+
+# Ensures KUBECONFIG points to the default config if not already set
+kube_set_default_config() {
+    if [ -z "$KUBECONFIG" ]; then
+        export KUBECONFIG="$HOME/.kube/config"
+    fi
+}
+
+# Prints the current Kubernetes context for use in prompts
+kube_prompt_context() {
+    kubectl config current-context 2>/dev/null || true
+}
+
+kube_set_default_config

--- a/tests/plugin_aws.bats
+++ b/tests/plugin_aws.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    export HOME="$BATS_TEST_TMPDIR"
+    # shellcheck disable=SC2034
+    color_blue=""
+    # shellcheck disable=SC2034
+    color_red=""
+    # shellcheck disable=SC2034
+    color_green=""
+    # shellcheck disable=SC2034
+    color_yellow=""
+    # shellcheck disable=SC2034
+    color_reset=""
+    # shellcheck source=../lib/core.sh disable=SC1091
+    source "$PMS/lib/core.sh"
+    # shellcheck source=../lib/cli.sh disable=SC1091
+    source "$PMS/lib/cli.sh"
+}
+
+@test "enabling aws plugin adds awsp alias" {
+    __pms_command_plugin_enable aws
+    alias awsp >/dev/null 2>&1
+}
+
+@test "aws plugin awsp sets AWS_PROFILE" {
+    __pms_command_plugin_enable aws
+    aws_set_profile prod
+    [ "$AWS_PROFILE" = "prod" ]
+}
+
+@test "disabling aws plugin removes it from enabled list" {
+    __pms_command_plugin_enable aws
+    __pms_command_plugin_disable aws
+    run _pms_is_plugin_enabled aws
+    [ "$status" -eq 1 ]
+}

--- a/tests/plugin_kubernetes.bats
+++ b/tests/plugin_kubernetes.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    export HOME="$BATS_TEST_TMPDIR"
+    # shellcheck disable=SC2034
+    color_blue=""
+    # shellcheck disable=SC2034
+    color_red=""
+    # shellcheck disable=SC2034
+    color_green=""
+    # shellcheck disable=SC2034
+    color_yellow=""
+    # shellcheck disable=SC2034
+    color_reset=""
+    # shellcheck source=../lib/core.sh disable=SC1091
+    source "$PMS/lib/core.sh"
+    # shellcheck source=../lib/cli.sh disable=SC1091
+    source "$PMS/lib/cli.sh"
+}
+
+@test "enabling kubernetes plugin adds k alias" {
+    __pms_command_plugin_enable kubernetes
+    alias k >/dev/null 2>&1
+}
+
+@test "kubernetes plugin sets default KUBECONFIG" {
+    unset KUBECONFIG
+    __pms_command_plugin_enable kubernetes
+    [ "$KUBECONFIG" = "$HOME/.kube/config" ]
+}
+
+@test "disabling kubernetes plugin removes it from enabled list" {
+    __pms_command_plugin_enable kubernetes
+    __pms_command_plugin_disable kubernetes
+    run _pms_is_plugin_enabled kubernetes
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
## Summary
- introduce Kubernetes plugin with kubectl alias, KUBECONFIG helper and prompt context function
- add AWS plugin to manage AWS_PROFILE with alias and prompt helper
- document and test enable/disable flows and basic plugin behavior

## Testing
- `shellcheck tests/plugin_kubernetes.bats tests/plugin_aws.bats plugins/kubernetes/kubernetes.plugin.sh plugins/aws/aws.plugin.sh`
- `bats tests/plugin_kubernetes.bats tests/plugin_aws.bats`


------
https://chatgpt.com/codex/tasks/task_e_68a541f8bbc0832c915be0695bb483fc