### PR TITLE
Add shell validation for PMS

### DIFF
--- a/tests/pms_shell_validation.bats
+++ b/tests/pms_shell_validation.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+setup() {
+    # Configure a minimal PMS environment for testing
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins"
+    export PMS_DEBUG=0
+    export PMS_THEME=default
+    export HOME="$BATS_TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+}
+
+@test "pms.sh exits successfully for supported shell" {
+    run bash "$PMS/pms.sh" bash
+    [ "$status" -eq 0 ]
+}
+
+@test "pms.sh errors for unsupported shell" {
+    run bash "$PMS/pms.sh" fish
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unsupported shell: fish"* ]]
+}


### PR DESCRIPTION
## Summary
- define supported shells and validate before loading env
- guard against missing shell env file with clear error
- test supported and unsupported shell scenarios

## Testing
- `shellcheck pms.sh`
- `bats tests/pms_shell_validation.bats`
- `bats tests` *(fails: plugin install uses code from index; default zsh theme includes vcs_info; zsh plugin initializes completions; HISTSIZE defaults to 10000; SAVEHIST defaults to 10000; HISTFILE defaults to $HOME/.zsh_history; HIST_IGNORE_ALL_DUPS defaults to 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a5445907c0832c9ea70c320eb3e4be