### PR TITLE
Improve POSIX compliance in core and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS
 
-- Follow shell style used in this project: four-space indentation and POSIX-compatible syntax when possible.
+ - Follow shell style used in this project: four-space indentation and POSIX-compatible syntax when possible. Prefer single-bracket `[ ]` tests over `[[ ]]`.
 - Use descriptive variable names; avoid single-letter names except for indexes.
 - Run `shellcheck` on all modified shell scripts.
 - If tests exist, run them and ensure each test method covers one execution path.

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -163,9 +163,13 @@ _pms_plugin_load() {
       local plugin_loaded=0
 
       # The env file is loaded first as there are options that it may use
-      if [[ -f "$PMS_LOCAL/plugins/$plugin/env" && "$plugin" != "$PMS_SHELL" && "$plugin" != "pms" ]]; then
+      if [ -f "$PMS_LOCAL/plugins/$plugin/env" ] \
+        && [ "$plugin" != "$PMS_SHELL" ] \
+        && [ "$plugin" != "pms" ]; then
         _pms_source_file "$PMS_LOCAL/plugins/$plugin/env"
-      elif [[ -f "$PMS/plugins/$plugin/env" && "$plugin" != "$PMS_SHELL" && "$plugin" != "pms" ]]; then
+      elif [ -f "$PMS/plugins/$plugin/env" ] \
+        && [ "$plugin" != "$PMS_SHELL" ] \
+        && [ "$plugin" != "pms" ]; then
         _pms_source_file "$PMS/plugins/$plugin/env"
       fi
 

--- a/pms.sh
+++ b/pms.sh
@@ -79,7 +79,7 @@ fi
 # Load all enabled plugins
 ####
 for plugin in "${PMS_PLUGINS[@]}"; do
-    if [[ "$plugin" != "$PMS_SHELL" && "$plugin" != "pms" ]]; then
+    if [ "$plugin" != "$PMS_SHELL" ] && [ "$plugin" != "pms" ]; then
         _pms_time "$plugin" _pms_plugin_load "$plugin"
     fi
 done

--- a/tests/dotfiles_command.bats
+++ b/tests/dotfiles_command.bats
@@ -37,17 +37,26 @@ setup() {
 @test "dotfiles command shows help without subcommand" {
     run pms dotfiles
     [ "$status" -eq 1 ]
-    [[ "$output" == *"Usage: pms [options] dotfiles <command>"* ]]
+    case "$output" in
+        *"Usage: pms [options] dotfiles <command>"*) ;;
+        *) false ;;
+    esac
 }
 
 @test "dotfiles status lists modified files" {
     run pms dotfiles status
     [ "$status" -eq 0 ]
-    [[ "$output" == *"modified:   testfile.txt"* ]]
+    case "$output" in
+        *"modified:   testfile.txt"*) ;;
+        *) false ;;
+    esac
 }
 
 @test "dotfiles diff shows file changes" {
     run pms dotfiles diff
     [ "$status" -eq 0 ]
-    [[ "$output" == *"+modified"* ]]
+    case "$output" in
+        *"+modified"*) ;;
+        *) false ;;
+    esac
 }

--- a/tests/plugin_enable_interactive.bats
+++ b/tests/plugin_enable_interactive.bats
@@ -34,5 +34,8 @@ FZF
 
 @test "plugin enable uses fzf when no argument" {
     __pms_command_plugin_enable
-    [[ "${PMS_PLUGINS[*]}" == *"bash"* ]]
+    case " ${PMS_PLUGINS[*]} " in
+        *" bash "*) ;;
+        *) false ;;
+    esac
 }

--- a/tests/plugin_load_missing.bats
+++ b/tests/plugin_load_missing.bats
@@ -24,6 +24,9 @@ setup() {
 @test "_pms_plugin_load reports missing plugins" {
     run _pms_plugin_load "missing"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"Plugin 'missing' could not be loaded"* ]]
+    case "$output" in
+        *"Plugin 'missing' could not be loaded"*) ;;
+        *) false ;;
+    esac
 }
 

--- a/tests/plugin_load_timing.bats
+++ b/tests/plugin_load_timing.bats
@@ -27,11 +27,14 @@ setup() {
 @test "_pms_time records plugin load duration" {
     _pms_time "sample" _pms_plugin_load sample
     [ "${PMS_PLUGIN_TIME_NAMES[0]}" = "sample" ]
-    [[ "${PMS_PLUGIN_TIME_VALUES[0]}" -ge 0 ]]
+    [ "${PMS_PLUGIN_TIME_VALUES[0]}" -ge 0 ]
 }
 
 @test "__pms_command_diagnostic shows plugin timings" {
     _pms_time "sample" _pms_plugin_load sample
     run __pms_command_diagnostic
-    [[ "$output" == *"sample"* ]]
+    case "$output" in
+        *"sample"*) ;;
+        *) false ;;
+    esac
 }

--- a/tests/plugin_search.bats
+++ b/tests/plugin_search.bats
@@ -16,11 +16,30 @@ setup() {
     source "$PMS/lib/cli.sh"
 }
 
-@test "plugin search shows code and repository" {
+@test "plugin search shows code" {
     run __pms_command_plugin_search example
     [ "$status" -eq 0 ]
-    [[ "$output" == *"example"* ]]
-    [[ "$output" == *"Example Plugin"* ]]
-    [[ "$output" == *"pms-example-plugin.git"* ]]
+    case "$output" in
+        *example*) ;;
+        *) false ;;
+    esac
+}
+
+@test "plugin search shows description" {
+    run __pms_command_plugin_search example
+    [ "$status" -eq 0 ]
+    case "$output" in
+        *"Example Plugin"*) ;;
+        *) false ;;
+    esac
+}
+
+@test "plugin search shows repository" {
+    run __pms_command_plugin_search example
+    [ "$status" -eq 0 ]
+    case "$output" in
+        *"pms-example-plugin.git"*) ;;
+        *) false ;;
+    esac
 }
 

--- a/tests/project_file.bats
+++ b/tests/project_file.bats
@@ -34,7 +34,7 @@ EOP
     _pms_project_file_load
     status=$?
     [ "$status" -eq 0 ]
-    [[ "${PMS_PLUGINS[*]}" = "git docker" ]]
+    [ "${PMS_PLUGINS[*]}" = "git docker" ]
     [ "$PMS_THEME" = "monokai" ]
     popd >/dev/null
 }

--- a/tests/theme_load_default.bats
+++ b/tests/theme_load_default.bats
@@ -25,6 +25,9 @@ setup() {
     PMS_THEME="default"
     run _pms_theme_load "$PMS_THEME"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"[theme] Loading 'default' theme"* ]]
+    case "$output" in
+        *"[theme] Loading 'default' theme"*) ;;
+        *) false ;;
+    esac
 }
 

--- a/tests/theme_vcs_info_prompt.bats
+++ b/tests/theme_vcs_info_prompt.bats
@@ -7,6 +7,9 @@
         echo "$PROMPT"
     '
     [ "$status" -eq 0 ]
-    [[ "${lines[0]}" == *"vcs_info_msg_0_"* ]]
+    case "${lines[0]}" in
+        *"vcs_info_msg_0_"*) ;;
+        *) false ;;
+    esac
 }
 

--- a/tests/uninstall.bats
+++ b/tests/uninstall.bats
@@ -6,7 +6,10 @@
     run bash -c "printf 'N\n' | scripts/uninstall.sh"
     [ "$status" -eq 0 ]
     [ -f "$HOME/.pms.theme" ]
-    [[ "$output" == *Canceled* ]]
+    case "$output" in
+        *Canceled*) ;;
+        *) false ;;
+    esac
 }
 
 @test "uninstall removes files on uppercase Y" {
@@ -17,5 +20,8 @@
     [ "$status" -eq 0 ]
     [ ! -f "$HOME/.pms.theme" ]
     [ ! -d "$HOME/.pms" ]
-    [[ "$output" == *"PMS has been uninstalled"* ]]
+    case "$output" in
+        *"PMS has been uninstalled"*) ;;
+        *) false ;;
+    esac
 }


### PR DESCRIPTION
## Summary
- replace `[[` tests with POSIX `[ ]` equivalents in core scripts
- rewrite test assertions using `case` and split plugin search checks
- document single-bracket style in AGENTS guidelines

## Testing
- `shellcheck lib/core.sh pms.sh tests/dotfiles_command.bats tests/plugin_load_missing.bats tests/plugin_load_timing.bats tests/plugin_search.bats tests/theme_vcs_info_prompt.bats tests/project_file.bats tests/uninstall.bats tests/theme_load_default.bats tests/plugin_enable_interactive.bats`
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_68a545c957ec832cb84a46beb8b40002