### PR TITLE
Use tput for terminal color codes

### DIFF
--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -5,74 +5,71 @@
 #
 # Provides ANSI escape sequences for formatting terminal output.
 # Usage: wrap text with variables, e.g., "${color_red}text${color_reset}".
+# Depends on "tput" and a valid terminfo database to generate codes.
 ####
 
 # Determine whether the current terminal supports color output.
-# Considers the NO_COLOR environment variable and falls back to
-# querying terminfo via tput or inspecting the TERM variable.
+# Considers the NO_COLOR environment variable and requires tput to
+# report at least eight supported colors.
 supports_color() {
     [ -n "$NO_COLOR" ] && return 1
+    command -v tput >/dev/null 2>&1 || return 1
 
-    if command -v tput >/dev/null 2>&1; then
-        color_count=$(tput colors 2>/dev/null)
-        if [ -n "$color_count" ] && [ "$color_count" -ge 8 ]; then
-            return 0
-        fi
+    tput_color_count=$(tput colors 2>/dev/null)
+    if [ -n "$tput_color_count" ] && [ "$tput_color_count" -ge 8 ]; then
+        unset tput_color_count
+        return 0
     fi
 
-    case "$TERM" in
-        *color*|xterm*|screen*|vt100*)
-            return 0
-            ;;
-    esac
-
+    unset tput_color_count
     return 1
 }
 
 if supports_color; then
-    color_reset=$(printf '\033[0m')        # Reset all text formatting
+    # Reset
+    color_reset=$(tput sgr0 2>/dev/null)        # Reset all text formatting
 
     # Foreground colors
-    color_black=$(printf '\033[30m')       # Set foreground to black
-    color_red=$(printf '\033[31m')         # Set foreground to red
-    color_green=$(printf '\033[32m')       # Set foreground to green
-    color_yellow=$(printf '\033[33m')      # Set foreground to yellow
-    color_blue=$(printf '\033[34m')        # Set foreground to blue
-    color_magenta=$(printf '\033[35m')     # Set foreground to magenta
-    color_cyan=$(printf '\033[36m')        # Set foreground to cyan
-    color_white=$(printf '\033[37m')       # Set foreground to white
-    color_bright_black=$(printf '\033[90m')   # Set foreground to bright black
-    color_bright_red=$(printf '\033[91m')     # Set foreground to bright red
-    color_bright_green=$(printf '\033[92m')   # Set foreground to bright green
-    color_bright_yellow=$(printf '\033[93m')  # Set foreground to bright yellow
-    color_bright_blue=$(printf '\033[94m')    # Set foreground to bright blue
-    color_bright_magenta=$(printf '\033[95m') # Set foreground to bright magenta
-    color_bright_cyan=$(printf '\033[96m')    # Set foreground to bright cyan
-    color_bright_white=$(printf '\033[97m')   # Set foreground to bright white
+    color_black=$(tput setaf 0 2>/dev/null)       # Set foreground to black
+    color_red=$(tput setaf 1 2>/dev/null)         # Set foreground to red
+    color_green=$(tput setaf 2 2>/dev/null)       # Set foreground to green
+    color_yellow=$(tput setaf 3 2>/dev/null)      # Set foreground to yellow
+    color_blue=$(tput setaf 4 2>/dev/null)        # Set foreground to blue
+    color_magenta=$(tput setaf 5 2>/dev/null)     # Set foreground to magenta
+    color_cyan=$(tput setaf 6 2>/dev/null)        # Set foreground to cyan
+    color_white=$(tput setaf 7 2>/dev/null)       # Set foreground to white
+    color_bright_black=$(tput setaf 8 2>/dev/null)   # Set foreground to bright black
+    color_bright_red=$(tput setaf 9 2>/dev/null)     # Set foreground to bright red
+    color_bright_green=$(tput setaf 10 2>/dev/null)  # Set foreground to bright green
+    color_bright_yellow=$(tput setaf 11 2>/dev/null) # Set foreground to bright yellow
+    color_bright_blue=$(tput setaf 12 2>/dev/null)   # Set foreground to bright blue
+    color_bright_magenta=$(tput setaf 13 2>/dev/null) # Set foreground to bright magenta
+    color_bright_cyan=$(tput setaf 14 2>/dev/null)    # Set foreground to bright cyan
+    color_bright_white=$(tput setaf 15 2>/dev/null)   # Set foreground to bright white
 
     # Background colors
-    color_bg_black=$(printf '\033[40m')       # Set background to black
-    color_bg_red=$(printf '\033[41m')         # Set background to red
-    color_bg_green=$(printf '\033[42m')       # Set background to green
-    color_bg_yellow=$(printf '\033[43m')      # Set background to yellow
-    color_bg_blue=$(printf '\033[44m')        # Set background to blue
-    color_bg_magenta=$(printf '\033[45m')     # Set background to magenta
-    color_bg_cyan=$(printf '\033[46m')        # Set background to cyan
-    color_bg_white=$(printf '\033[47m')       # Set background to white
-    color_bg_bright_black=$(printf '\033[100m')   # Set background to bright black
-    color_bg_bright_red=$(printf '\033[101m')     # Set background to bright red
-    color_bg_bright_green=$(printf '\033[102m')   # Set background to bright green
-    color_bg_bright_yellow=$(printf '\033[103m')  # Set background to bright yellow
-    color_bg_bright_blue=$(printf '\033[104m')    # Set background to bright blue
-    color_bg_bright_magenta=$(printf '\033[105m') # Set background to bright magenta
-    color_bg_bright_cyan=$(printf '\033[106m')    # Set background to bright cyan
-    color_bg_bright_white=$(printf '\033[107m')   # Set background to bright white
+    color_bg_black=$(tput setab 0 2>/dev/null)       # Set background to black
+    color_bg_red=$(tput setab 1 2>/dev/null)         # Set background to red
+    color_bg_green=$(tput setab 2 2>/dev/null)       # Set background to green
+    color_bg_yellow=$(tput setab 3 2>/dev/null)      # Set background to yellow
+    color_bg_blue=$(tput setab 4 2>/dev/null)        # Set background to blue
+    color_bg_magenta=$(tput setab 5 2>/dev/null)     # Set background to magenta
+    color_bg_cyan=$(tput setab 6 2>/dev/null)        # Set background to cyan
+    color_bg_white=$(tput setab 7 2>/dev/null)       # Set background to white
+    color_bg_bright_black=$(tput setab 8 2>/dev/null)   # Set background to bright black
+    color_bg_bright_red=$(tput setab 9 2>/dev/null)     # Set background to bright red
+    color_bg_bright_green=$(tput setab 10 2>/dev/null)  # Set background to bright green
+    color_bg_bright_yellow=$(tput setab 11 2>/dev/null) # Set background to bright yellow
+    color_bg_bright_blue=$(tput setab 12 2>/dev/null)   # Set background to bright blue
+    color_bg_bright_magenta=$(tput setab 13 2>/dev/null) # Set background to bright magenta
+    color_bg_bright_cyan=$(tput setab 14 2>/dev/null)    # Set background to bright cyan
+    color_bg_bright_white=$(tput setab 15 2>/dev/null)   # Set background to bright white
 
     # Text effects
-    color_bold=$(printf '\033[1m')          # Apply bold style
-    color_dim=$(printf '\033[2m')           # Apply dim style
-    color_underline=$(printf '\033[4m')     # Apply underline style
-    color_reverse=$(printf '\033[7m')       # Swap foreground and background
+    color_bold=$(tput bold 2>/dev/null)          # Apply bold style
+    color_dim=$(tput dim 2>/dev/null)            # Apply dim style
+    color_underline=$(tput smul 2>/dev/null)     # Apply underline style
+    color_reverse=$(tput rev 2>/dev/null)        # Swap foreground and background
 else
     color_reset=''        # Reset all text formatting
 


### PR DESCRIPTION
## Summary
- Replace ANSI escape sequences with `tput`-based color codes
- Require `tput`/terminfo for color support and cache codes in variables

## Testing
- `shellcheck lib/colors.sh`
- `bats tests` *(fails: `zsh` command not found and several tests not ok)*

------
https://chatgpt.com/codex/tasks/task_e_68a547c382f4832cb8dd6d9a2dbdd57f