### PR TITLE
Improve script docs and env variable clarity

### DIFF
--- a/pms.sh
+++ b/pms.sh
@@ -1,12 +1,23 @@
 ####
 # PMS
 #
-# This is the main entry point for PMS.
+# Main entry point for PMS. Loads libraries, plugins, and themes for the
+# requested shell.
+#
+# Usage:
+#   PMS=/path/to/pms ./pms.sh bash
+#
+# Environment Variables:
+#   PMS          Path to the PMS installation directory
+#   PMS_DEBUG    Set to 1 to enable verbose debug output
+#   PMS_SHELL    Target shell to configure (e.g., bash, zsh)
+#   PMS_PLUGINS  Space-separated list of plugins to load
+#   PMS_THEME    Name of the theme to load
 ####
 # shellcheck shell=bash
 
 # Define shells supported by PMS
-supported_shells="bash zsh"
+PMS_SUPPORTED_SHELLS="bash zsh"
 
 # Validate we can properly configure the shell
 if [ -z "$1" ]; then
@@ -31,7 +42,7 @@ if [ 1 -eq "${PMS_DEBUG:-0}" ]; then
 fi
 
 # Ensure the requested shell is supported and its environment file exists
-case " $supported_shells " in
+case " $PMS_SUPPORTED_SHELLS " in
     *" $PMS_SHELL "*) ;;
     *)
         echo "Unsupported shell: $PMS_SHELL"
@@ -39,17 +50,17 @@ case " $supported_shells " in
         ;;
 esac
 
-shell_env="$PMS/plugins/$PMS_SHELL/env"
-if [ ! -f "$shell_env" ]; then
-    echo "Environment file not found: $shell_env"
+PMS_SHELL_ENV_FILE="$PMS/plugins/$PMS_SHELL/env"
+if [ ! -f "$PMS_SHELL_ENV_FILE" ]; then
+    echo "Environment file not found: $PMS_SHELL_ENV_FILE"
     exit 1
 fi
 
 # If the shell has any variables that need to be set, we need to make sure they get set
 # shellcheck disable=SC1090
-source "$shell_env"
+source "$PMS_SHELL_ENV_FILE"
 if [ 1 -eq "${PMS_DEBUG:-0}" ]; then
-    echo "source $shell_env"
+    echo "source $PMS_SHELL_ENV_FILE"
 fi
 
 ####

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,54 +1,66 @@
 #!/usr/bin/env sh
 #
-# Environment Variables
-#   PMS         = path to PMS repository
-#   PMS_DEBUG   = 1 = enabled, 0 = disabled
-#   PMS_REPO    = default: JoshuaEstes/pms
-#   PMS_REMOTE  = default: https://github.com/$PMS_REPO.git
-#   PMS_BRANCH  = main
-#   PMS_SHELL   = target shell to configure (bash, zsh, etc.)
+# Install PMS into the target directory and configure the user's shell.
 #
+# Usage:
+#   PMS_INSTALL_DIR=/opt/pms scripts/install.sh
+#
+# Environment Variables:
+#   PMS_INSTALL_DIR  Path where PMS should be installed (default: ~/.pms)
+#   PMS_DEBUG        Set to 1 to enable verbose debug output
+#   PMS_REPO         Repository to clone (default: JoshuaEstes/pms)
+#   PMS_REMOTE       Remote URL of the repository (default: https://github.com/$PMS_REPO.git)
+#   PMS_BRANCH       Branch to checkout (default: main)
+#   PMS_SHELL        Target shell to configure (bash, zsh, etc.)
+####
+# shellcheck shell=sh
+
 set -e
-PMS=${PMS:-~/.pms}
+PMS_INSTALL_DIR=${PMS_INSTALL_DIR:-${PMS:-~/.pms}}
 PMS_DEBUG=${PMS_DEBUG:-0}
 PMS_REPO=${PMS_REPO:-JoshuaEstes/pms}
 PMS_REMOTE=${PMS_REMOTE:-https://github.com/${PMS_REPO}.git}
 PMS_BRANCH=${PMS_BRANCH:-main}
 PMS_SHELL=${PMS_SHELL:-${SHELL##*/}}
 
+
+# setup_pms clones the PMS repository and copies default configuration files.
 setup_pms() {
     printf '\r\n\t%sCloning PMS...%s\n\n' "$BLUE" "$RESET"
 
-    git clone --depth=1 --branch "$PMS_BRANCH" "$PMS_REMOTE" "$PMS" || {
+    git clone --depth=1 --branch "$PMS_BRANCH" "$PMS_REMOTE" "$PMS_INSTALL_DIR" || {
         echo "${RED}ERROR: git clone command failed${RESET}"
         exit 1
     }
 
     # Copy over config files if they do not currently exist
     echo "${BLUE}Copying PMS Environment Variables file over, this file stores various PMS settings that can be modified${RESET}"
-    cp -vfi "$PMS/templates/env" "$HOME/.env"
+    cp -vfi "$PMS_INSTALL_DIR/templates/env" "$HOME/.env"
 
     echo "${BLUE}Copying PMS Theme Config File, this file is used to store your currently selected theme${RESET}"
-    cp -vfi "$PMS/templates/pms.theme" "$HOME/.pms.theme"
+    cp -vfi "$PMS_INSTALL_DIR/templates/pms.theme" "$HOME/.pms.theme"
 
     echo "${BLUE}Copying PMS Plugins Config File, this file contains all your enabled plugins${RESET}"
-    cp -vfi "$PMS/templates/pms.plugins" "$HOME/.pms.plugins"
+    cp -vfi "$PMS_INSTALL_DIR/templates/pms.plugins" "$HOME/.pms.plugins"
 }
 
+
+# _setup_shell_rc backs up any existing RC file and installs the PMS version.
 _setup_shell_rc() {
     shell_name="$1"
-    rc_file="${shell_name}rc"
-    if [ -f "$HOME/.${rc_file}" ] || [ -h "$HOME/.${rc_file}" ]; then
-        echo "${YELLOW}Found existing .${rc_file} file, backing up${RESET}"
-        if [ ! -f "$HOME/.${rc_file}.pms.bak" ]; then
-            echo "${YELLOW}Moving $HOME/.${rc_file} -> $HOME/.${rc_file}.pms.bak${RESET}"
-            mv -vfi "$HOME/.${rc_file}" "$HOME/.${rc_file}.pms.bak"
+    shell_rc_file="${shell_name}rc"
+    if [ -f "$HOME/.${shell_rc_file}" ] || [ -h "$HOME/.${shell_rc_file}" ]; then
+        echo "${YELLOW}Found existing .${shell_rc_file} file, backing up${RESET}"
+        if [ ! -f "$HOME/.${shell_rc_file}.pms.bak" ]; then
+            echo "${YELLOW}Moving $HOME/.${shell_rc_file} -> $HOME/.${shell_rc_file}.pms.bak${RESET}"
+            mv -vfi "$HOME/.${shell_rc_file}" "$HOME/.${shell_rc_file}.pms.bak"
         fi
     fi
-    echo "${BLUE}Copy $PMS/templates/${rc_file} -> $HOME/.${rc_file} ${RESET}"
-    cp -vf "$PMS/templates/${rc_file}" "$HOME/.${rc_file}"
+    echo "${BLUE}Copy $PMS_INSTALL_DIR/templates/${shell_rc_file} -> $HOME/.${shell_rc_file} ${RESET}"
+    cp -vf "$PMS_INSTALL_DIR/templates/${shell_rc_file}" "$HOME/.${shell_rc_file}"
 }
 
+# setup_shell configures the user's shell and sets it as default if possible.
 setup_shell() {
     printf '\r\n\t%sSetting up shell...%s\n\n' "$BLUE" "$RESET"
     case "$PMS_SHELL" in
@@ -68,7 +80,7 @@ setup_shell() {
     esac
 }
 
-# Main function, this will be called to install everything
+# main orchestrates the installation process.
 main() {
   umask g-w,o-w
 
@@ -88,12 +100,12 @@ main() {
 
   if [ "$PMS_DEBUG" -eq "1" ]; then
       printf '%s' "$YELLOW"
-    echo "PMS:         $PMS"
-    echo "PMS_DEBUG:   $PMS_DEBUG"
-    echo "PMS_REPO:    $PMS_REPO"
-    echo "PMS_REMOTE:  $PMS_REMOTE"
-    echo "PMS_BRANCH:  $PMS_BRANCH"
-    echo "PMS_SHELL:   $PMS_SHELL"
+    echo "PMS_INSTALL_DIR: $PMS_INSTALL_DIR"
+    echo "PMS_DEBUG:       $PMS_DEBUG"
+    echo "PMS_REPO:        $PMS_REPO"
+    echo "PMS_REMOTE:      $PMS_REMOTE"
+    echo "PMS_BRANCH:      $PMS_BRANCH"
+    echo "PMS_SHELL:       $PMS_SHELL"
       printf '%s' "$RESET"
   fi
 
@@ -107,7 +119,7 @@ main() {
       exit 1
   fi
 
-  if [ -d "$PMS" ]; then
+  if [ -d "$PMS_INSTALL_DIR" ]; then
       echo "${YELLOW}Looks like PMS is already installed on your system. Please remove it and run this script again.${RESET}"
       exit 1
   fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,13 +1,29 @@
 #!/usr/bin/env bash
+#
+# Uninstall PMS and restore original shell configuration.
+#
+# Usage:
+#   scripts/uninstall.sh [-n]
+#
+# Options:
+#   -n  Run non-interactively and assume "yes" for prompts.
+#
+# Environment Variables:
+#   PMS_INSTALL_DIR  Directory where PMS is installed (default: ~/.pms)
+####
+# shellcheck shell=bash
+
 set -e
 # Set to 1 to skip prompts.
-NO_INTERACTION=0
+UNINSTALL_NO_INTERACTION=0
+PMS_INSTALL_DIR=${PMS_INSTALL_DIR:-$HOME/.pms}
 
+# main orchestrates the uninstallation process.
 main() {
     while getopts "n" option; do
         case ${option} in
             n)
-                NO_INTERACTION=1
+                UNINSTALL_NO_INTERACTION=1
                 ;;
             *)
                 return 1
@@ -16,9 +32,9 @@ main() {
     done
 
     # Confirm with user they really want to uninstall PMS
-    if [ "$NO_INTERACTION" -eq "0" ]; then
-        read -r -p "Are you sure you want to uninstall PMS? [y/N] " confirm
-        if [ "${confirm}" != "y" ] && [ "${confirm}" != "Y" ]; then
+    if [ "$UNINSTALL_NO_INTERACTION" -eq "0" ]; then
+        read -r -p "Are you sure you want to uninstall PMS? [y/N] " user_response
+        if [ "$user_response" != "y" ] && [ "$user_response" != "Y" ]; then
             echo "Canceled"
             exit
         fi
@@ -26,9 +42,9 @@ main() {
 
     # Revert rc files (user confirmation)
     if [ -f ~/.bashrc.pms.bak ] && [ -f ~/.bashrc ]; then
-        if [ "$NO_INTERACTION" -eq "0" ]; then
-            read -r -p "Restore your ~/.bashrc with the backup ~/.bashrc.pms.bak? [Y/n] " confirm
-            if [ "${confirm}" != "n" ] && [ "${confirm}" != "N" ]; then
+        if [ "$UNINSTALL_NO_INTERACTION" -eq "0" ]; then
+            read -r -p "Restore your ~/.bashrc with the backup ~/.bashrc.pms.bak? [Y/n] " user_response
+            if [ "$user_response" != "n" ] && [ "$user_response" != "N" ]; then
                 mv ~/.bashrc.pms.bak ~/.bashrc
             fi
         else
@@ -36,9 +52,9 @@ main() {
         fi
     fi
     if [ -f ~/.zshrc.pms.bak ] && [ -f ~/.zshrc ]; then
-        if [ "$NO_INTERACTION" -eq "0" ]; then
-            read -r -p "Restore your ~/.zshrc with the backup ~/.zshrc.pms.bak? [Y/n] " confirm
-            if [ "${confirm}" != "n" ] && [ "${confirm}" != "N" ]; then
+        if [ "$UNINSTALL_NO_INTERACTION" -eq "0" ]; then
+            read -r -p "Restore your ~/.zshrc with the backup ~/.zshrc.pms.bak? [Y/n] " user_response
+            if [ "$user_response" != "n" ] && [ "$user_response" != "N" ]; then
                 mv ~/.zshrc.pms.bak ~/.zshrc
             fi
         else
@@ -54,9 +70,9 @@ main() {
 
     # Delete .env (user confirmation)
     if [ -f ~/.env ]; then
-        if [ "$NO_INTERACTION" -eq "0" ]; then
-            read -r -p "Would you like to delete ~/.env file? [Y/n] " confirm
-            if [ "${confirm}" != "n" ] && [ "${confirm}" != "N" ]; then
+        if [ "$UNINSTALL_NO_INTERACTION" -eq "0" ]; then
+            read -r -p "Would you like to delete ~/.env file? [Y/n] " user_response
+            if [ "$user_response" != "n" ] && [ "$user_response" != "N" ]; then
                 rm -fv ~/.env
             fi
         else
@@ -64,9 +80,9 @@ main() {
         fi
     fi
 
-    # Delete $PMS directory
-    echo "Removing ~/.pms directory"
-    rm -rf ~/.pms
+    # Delete PMS directory
+    echo "Removing $PMS_INSTALL_DIR directory"
+    rm -rf "$PMS_INSTALL_DIR"
 
     echo "PMS has been uninstalled. You should restart your terminal"
 }


### PR DESCRIPTION
## Summary
- document entrypoint usage and key env vars in `pms.sh`
- clarify install/uninstall scripts with usage examples and descriptive variable names
- add function-level comments across scripts

## Testing
- `shellcheck pms.sh scripts/install.sh scripts/uninstall.sh`
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_68a5484888ec832cbf0e62edc096d08e