### PR TITLE
feat: add colorize helper

### DIFF
--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -115,3 +115,22 @@ else
     color_underline=''
     color_reverse=''
 fi
+
+####
+# Apply a color to text and reset formatting
+#
+# Usage: colorize <color_var> "<text>"
+#
+# Arguments:
+#   color_var - name of the color variable to apply
+#   text      - text to colorize
+####
+colorize() {
+    color_var=$1
+    color_text=$2
+
+    eval "printf '%s%s%s\n' \"\${$color_var}\" \"$color_text\" \"$color_reset\""
+
+    unset color_var
+    unset color_text
+}

--- a/lib/colors.zsh
+++ b/lib/colors.zsh
@@ -1,4 +1,5 @@
 # vim: set ft=zsh:
+# shellcheck shell=bash disable=SC2034,SC2154,SC2296
 ####
 # Colors
 ####
@@ -8,3 +9,23 @@
 # $fg and $bg
 # @see https://github.com/zsh-users/zsh/blob/master/Functions/Misc/colors
 autoload -U colors && colors
+color_reset=$reset_color
+
+####
+# Apply a color to text and reset formatting
+#
+# Usage: colorize <color_var> "<text>"
+#
+# Arguments:
+#   color_var - name of the $fg or $bg color to apply
+#   text      - text to colorize
+####
+colorize() {
+    color_var=$1
+    color_text=$2
+
+    printf '%s%s%s\n' "${(P)color_var}" "$color_text" "$color_reset"
+
+    unset color_var
+    unset color_text
+}


### PR DESCRIPTION
## Summary
- add `colorize` function to color utilities and auto-append reset sequence
- expose `color_reset` in zsh colors and mirror helper for `$fg`/`$bg`

## Testing
- `shellcheck lib/colors.sh lib/colors.zsh`
- `bats tests` *(fails: zsh command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a54a1e79bc832cb7a2074eb6942393