### PR TITLE
style: document bash plugin and fix indentation

### DIFF
--- a/plugins/bash/bash.plugin.bash
+++ b/plugins/bash/bash.plugin.bash
@@ -1,22 +1,34 @@
+# vim: set ft=sh:
+# shellcheck shell=bash
+####
 # Plugin: bash
-HISTCONTROL=ignoreboth
+####
+# Configures history options, common aliases, and completion for Bash.
+
+HISTCONTROL=ignoreboth   # ignore duplicates and commands starting with spaces
 HISTSIZE=1000
 HISTFILESIZE=2000
 shopt -s histappend
 shopt -s checkwinsize
 
+# Useful directory listings
 alias ll='ls -alF'
 alias la='ls -A'
 alias l='ls -CF'
 
+# Source personal aliases if present
 if [ -f ~/.bash_aliases ]; then
+    # shellcheck source=/dev/null
     source ~/.bash_aliases
 fi
 
+# Load bash completion if available
 if ! shopt -oq posix; then
-  if [ -f /usr/share/bash-completion/bash_completion ]; then
-    source /usr/share/bash-completion/bash_completion
-  elif [ -f /etc/bash_completion ]; then
-    source /etc/bash_completion
-  fi
+    if [ -f /usr/share/bash-completion/bash_completion ]; then
+        # shellcheck source=/usr/share/bash-completion/bash_completion disable=SC1091
+        source /usr/share/bash-completion/bash_completion
+    elif [ -f /etc/bash_completion ]; then
+        # shellcheck source=/etc/bash_completion disable=SC1091
+        source /etc/bash_completion
+    fi
 fi


### PR DESCRIPTION
## Summary
- standardize bash plugin indentation to four spaces
- document plugin intent and enable shellcheck with directive

## Testing
- `shellcheck plugins/bash/bash.plugin.bash`
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_68a5586ea818832c97710899d00b6c24