### PR TITLE
test: add interactive message tests

### DIFF
--- a/tests/message_block_formats_plain.bats
+++ b/tests/message_block_formats_plain.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+# Verify that _pms_message_block prints plain text when no type is given.
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    # shellcheck disable=SC2034
+    color_blue="<blue>"
+    # shellcheck disable=SC2034
+    color_green="<green>"
+    # shellcheck disable=SC2034
+    color_yellow="<yellow>"
+    # shellcheck disable=SC2034
+    color_red="<red>"
+    # shellcheck disable=SC2034
+    color_reset="<reset>"
+    # shellcheck source=../lib/core/interactive.sh disable=SC1091
+    source "$PMS/lib/core/interactive.sh"
+}
+
+@test "message_block formats plain text when type absent" {
+    run _pms_message_block "Notice"
+    [ "$status" -eq 0 ]
+    [ "$output" = $'\r\n\tNotice\n\n' ]
+}

--- a/tests/message_formats_info.bats
+++ b/tests/message_formats_info.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+# Verify that _pms_message applies blue color for info type.
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    # shellcheck disable=SC2034
+    color_blue="<blue>"
+    # shellcheck disable=SC2034
+    color_green="<green>"
+    # shellcheck disable=SC2034
+    color_yellow="<yellow>"
+    # shellcheck disable=SC2034
+    color_red="<red>"
+    # shellcheck disable=SC2034
+    color_reset="<reset>"
+    # shellcheck source=../lib/core/interactive.sh disable=SC1091
+    source "$PMS/lib/core/interactive.sh"
+}
+
+@test "message formats info with colors" {
+    run _pms_message info "Info text"
+    [ "$status" -eq 0 ]
+    [ "$output" = $'\r<blue>Info text<reset>\n' ]
+}

--- a/tests/message_section_formats_warn.bats
+++ b/tests/message_section_formats_warn.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+# Ensure _pms_message_section formats a warning with yellow section label.
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    # shellcheck disable=SC2034
+    color_blue="<blue>"
+    # shellcheck disable=SC2034
+    color_green="<green>"
+    # shellcheck disable=SC2034
+    color_yellow="<yellow>"
+    # shellcheck disable=SC2034
+    color_red="<red>"
+    # shellcheck disable=SC2034
+    color_reset="<reset>"
+    # shellcheck source=../lib/core/interactive.sh disable=SC1091
+    source "$PMS/lib/core/interactive.sh"
+}
+
+@test "message_section formats warn with colors" {
+    run _pms_message_section warn "Build" "completed"
+    [ "$status" -eq 0 ]
+    [ "$output" = $'\r[<yellow>Build<reset>] completed<reset>\n' ]
+}

--- a/tests/question_yn_accepts_yes.bats
+++ b/tests/question_yn_accepts_yes.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+# Verify that _pms_question_yn returns success when user answers yes.
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    # shellcheck disable=SC2034
+    color_blue="<blue>"
+    # shellcheck disable=SC2034
+    color_green="<green>"
+    # shellcheck disable=SC2034
+    color_yellow="<yellow>"
+    # shellcheck disable=SC2034
+    color_red="<red>"
+    # shellcheck disable=SC2034
+    color_reset="<reset>"
+    # shellcheck source=../lib/core/interactive.sh disable=SC1091
+    source "$PMS/lib/core/interactive.sh"
+}
+
+# Feed a positive answer and expect a zero exit status.
+ask_yes() {
+    printf 'y\n' | _pms_question_yn
+}
+
+@test "question_yn returns success on yes" {
+    run ask_yes
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary
- add Bats tests for `_pms_question_yn` confirmation path
- cover `info`, `warn` section, and plain block messaging outputs with color mocks

## Testing
- `shellcheck tests/question_yn_accepts_yes.bats tests/message_formats_info.bats tests/message_section_formats_warn.bats tests/message_block_formats_plain.bats`
- `bats tests` *(fails: command not found for zsh-related tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a558a5452c832cb56fcab00e394336