### PR TITLE
docs: add READMEs for core plugins

### DIFF
--- a/plugins/bash/README.md
+++ b/plugins/bash/README.md
@@ -1,0 +1,9 @@
+# Bash
+
+Configures history behavior, enables window size checks, sources `~/.bash_aliases`, loads `bash_completion` when available, and defines common `ls` aliases.
+
+## Usage
+
+- `ll` – detailed `ls` output.
+- `la` – show hidden files.
+- `l` – compact listing.

--- a/plugins/cd/README.md
+++ b/plugins/cd/README.md
@@ -1,0 +1,7 @@
+# cd
+
+Adds `-` as an alias for `cd -`, allowing quick return to the previous directory.
+
+## Usage
+
+- `-` – jump back to the last directory.

--- a/plugins/composer/README.md
+++ b/plugins/composer/README.md
@@ -1,0 +1,12 @@
+# Composer
+
+Provides shortcuts for Composer and adds `~/.composer/vendor/bin` to `PATH`.
+
+## Configuration
+
+- `PMS_COMPOSER_AUTOUPDATE=1` – update Composer during PMS upgrades.
+
+## Usage
+
+- `c` – run `composer`.
+- `cup` – run `composer update`.

--- a/plugins/example/README.md
+++ b/plugins/example/README.md
@@ -1,0 +1,7 @@
+# Example
+
+Reference plugin demonstrating directory layout, environment files, and install/update hooks. Useful when building new plugins.
+
+## Usage
+
+Enabling the plugin has no user-facing behavior; inspect its files for guidance.

--- a/plugins/getting-started/README.md
+++ b/plugins/getting-started/README.md
@@ -1,0 +1,7 @@
+# Getting Started
+
+Displays onboarding tips and common PMS commands when enabled.
+
+## Usage
+
+Enabled by default. Disable with `pms plugin disable getting-started` once familiar.

--- a/plugins/history/README.md
+++ b/plugins/history/README.md
@@ -1,0 +1,12 @@
+# History
+
+Configures shell history defaults and provides shortcuts for viewing history statistics.
+
+## Configuration
+
+- `HISTFILE`, `HISTSIZE`, `SAVEHIST` – control history location and size.
+
+## Usage
+
+- `h` – show history.
+- `hstats` – list most used commands.

--- a/plugins/homebrew/README.md
+++ b/plugins/homebrew/README.md
@@ -1,0 +1,7 @@
+# Homebrew
+
+Adds Homebrew's bin directories to `PATH` and loads shell completions.
+
+## Usage
+
+Requires `brew` to be installed. Completions are loaded automatically when available.

--- a/plugins/jobs/README.md
+++ b/plugins/jobs/README.md
@@ -1,0 +1,7 @@
+# Jobs
+
+Adds `j` alias for `jobs` to quickly list background tasks.
+
+## Usage
+
+- `j` – list active jobs.

--- a/plugins/ls/README.md
+++ b/plugins/ls/README.md
@@ -1,0 +1,11 @@
+# LS
+
+Defines colorized `ls` aliases for quick directory listings.
+
+## Usage
+
+- `ls` – colorized output.
+- `ll` – detailed listing.
+- `la` – include hidden files.
+- `lsa` – list only hidden entries.
+- `lsd` – list directories only.

--- a/plugins/mkdir/README.md
+++ b/plugins/mkdir/README.md
@@ -1,0 +1,7 @@
+# Mkdir
+
+Adds alias `mkdir -vp` to create parent directories verbosely.
+
+## Usage
+
+- `mkdir path/to/new` – creates directories with output.

--- a/plugins/php/README.md
+++ b/plugins/php/README.md
@@ -1,0 +1,7 @@
+# PHP
+
+Adds the plugin's `bin` directory to `PATH` and supplies a `_php_version` helper for prompts.
+
+## Usage
+
+- `_php_version` – outputs the installed PHP version or `php:not-installed`.

--- a/plugins/phpbrew/README.md
+++ b/plugins/phpbrew/README.md
@@ -1,0 +1,14 @@
+# PHPBrew
+
+Loads PHPBrew integration and provides optional update hooks.
+
+## Configuration
+
+- `PHPBREW_SET_PROMPT` – set to `1` to show PHP version in the prompt.
+- `PHPBREW_RC_ENABLE` – search for `.phpbrewrc` files (default `1`).
+- `PMS_PHPBREW_SELFUPDATE` – run `phpbrew self-update` during PMS upgrades.
+- `PMS_PHPBREW_UPDATE` – refresh known PHP versions during PMS upgrades.
+
+## Usage
+
+Ensure PHPBrew is installed; the plugin sources `~/.phpbrew/bashrc` when present.

--- a/plugins/test-completion/README.md
+++ b/plugins/test-completion/README.md
@@ -1,0 +1,3 @@
+# Test Completion
+
+Sample plugin used in automated tests to verify completion directories are added to the shell.

--- a/plugins/tmux/README.md
+++ b/plugins/tmux/README.md
@@ -1,0 +1,7 @@
+# Tmux
+
+Installs the tmux plugin manager (TPM) and includes a status-right helper script showing date and system load.
+
+## Usage
+
+TPM is installed on first enable. Source `scripts/right.sh` in your `tmux.conf` to display status information.

--- a/plugins/vcs-info/README.md
+++ b/plugins/vcs-info/README.md
@@ -1,0 +1,7 @@
+# VCS Info
+
+Configures zsh `vcs_info` to show Git branch and status details in the prompt.
+
+## Usage
+
+The prompt displays branch, abbreviated revision, and flags for staged, unstaged, and untracked changes.

--- a/plugins/vim-mode/README.md
+++ b/plugins/vim-mode/README.md
@@ -1,0 +1,3 @@
+# Vim Mode
+
+Enables vi-style key bindings in zsh and shows the current mode in the right prompt.

--- a/plugins/vim/README.md
+++ b/plugins/vim/README.md
@@ -1,0 +1,11 @@
+# Vim
+
+Sets `vim` as the default editor and provides `v` and `vi` aliases.
+
+## Configuration
+
+- `EDITOR` and `FCEDITOR` are exported to `vim` via the plugin's env file.
+
+## Usage
+
+- `v file` – open `file` in Vim.

--- a/plugins/vundle/README.md
+++ b/plugins/vundle/README.md
@@ -1,0 +1,7 @@
+# Vundle
+
+Integrates [Vundle](https://github.com/VundleVim/Vundle.vim) updates with PMS.
+
+## Configuration
+
+- `PMS_VUNDLE_AUTOUPDATE=1` – run `vim -c VundleUpdate -c quitall` during PMS upgrades.

--- a/plugins/zsh/README.md
+++ b/plugins/zsh/README.md
@@ -1,0 +1,7 @@
+# Zsh
+
+Configures zsh options, history defaults, and completion setup using `compinit`.
+
+## Configuration
+
+Set `DIRSTACKSIZE`, `KEYTIMEOUT`, `HISTFILE`, `HISTSIZE`, or `SAVEHIST` before loading to override the defaults from the plugin's `env` file.


### PR DESCRIPTION
## Summary
- add README for Bash plugin highlighting history settings and aliases
- document Composer plugin shortcuts and autoupdate flag
- describe Zsh plugin options and customizable history variables
- add similar concise READMEs for other core plugins

## Testing
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_68a5585afcc0832c9613be640a680915