### PR TITLE
feat: add file copy helper and quote upgrade paths

### DIFF
--- a/tests/file_copy_copies_file.bats
+++ b/tests/file_copy_copies_file.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    # shellcheck disable=SC2034
+    color_blue=""
+    # shellcheck disable=SC2034
+    color_red=""
+    # shellcheck disable=SC2034
+    color_green=""
+    # shellcheck disable=SC2034
+    color_yellow=""
+    # shellcheck disable=SC2034
+    color_reset=""
+    # shellcheck source=../lib/core.sh disable=SC1091
+    source "$PMS/lib/core.sh"
+    # shellcheck source=../lib/cli.sh disable=SC1091
+    source "$PMS/lib/cli.sh"
+}
+
+@test "_pms_file_copy copies files" {
+    touch "$BATS_TEST_TMPDIR/src"
+    run _pms_file_copy "$BATS_TEST_TMPDIR/src" "$BATS_TEST_TMPDIR/dest"
+    [ "$status" -eq 0 ]
+    [ -f "$BATS_TEST_TMPDIR/dest" ]
+}
+

--- a/tests/file_copy_missing_source_returns_error.bats
+++ b/tests/file_copy_missing_source_returns_error.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=0
+    # shellcheck disable=SC2034
+    color_blue=""
+    # shellcheck disable=SC2034
+    color_red=""
+    # shellcheck disable=SC2034
+    color_green=""
+    # shellcheck disable=SC2034
+    color_yellow=""
+    # shellcheck disable=SC2034
+    color_reset=""
+    # shellcheck source=../lib/core.sh disable=SC1091
+    source "$PMS/lib/core.sh"
+    # shellcheck source=../lib/cli.sh disable=SC1091
+    source "$PMS/lib/cli.sh"
+}
+
+@test "_pms_file_copy returns error for missing source" {
+    run _pms_file_copy "$BATS_TEST_TMPDIR/missing" "$BATS_TEST_TMPDIR/dest"
+    [ "$status" -ne 0 ]
+}
+


### PR DESCRIPTION
## Summary
- add `_pms_file_copy` wrapper for safe copying
- use helper during upgrade and quote plugin paths
- cover file copy helper with tests

## Testing
- `shellcheck lib/cli.sh tests/file_copy_copies_file.bats tests/file_copy_missing_source_returns_error.bats`
- `bats tests` *(fails: command not found zsh and related warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a55ad7ebac832ca188a4d5aadc559b