### PR TITLE
feat(theme): confirm before disabling plugins

### DIFF
--- a/themes/joshuaestes/uninstall.sh
+++ b/themes/joshuaestes/uninstall.sh
@@ -1,5 +1,19 @@
 # vim: set ft=sh:
-# @todo Ask confirmation before disabling
-#pms plugin disable vcs-info
-#pms plugin disable vim-mode
-#pms plugin disable php
+# shellcheck shell=sh
+####
+# Disable plugins installed with the joshuaestes theme.
+# Prompts for confirmation unless UNINSTALL_NO_INTERACTION=1.
+####
+
+if [ "${UNINSTALL_NO_INTERACTION:-0}" -eq 0 ]; then
+    printf 'Disable plugins vcs-info, vim-mode, and php? [y/N] '
+    read -r disable_plugins
+    if [ "$disable_plugins" != "y" ] && [ "$disable_plugins" != "Y" ]; then
+        echo "Canceled"
+        return
+    fi
+fi
+
+pms plugin disable vcs-info >/dev/null 2>&1 || true
+pms plugin disable vim-mode >/dev/null 2>&1 || true
+pms plugin disable php >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- prompt before disabling joshuaestes theme plugins, honoring UNINSTALL_NO_INTERACTION
- execute plugin disable commands after confirmation

## Testing
- `shellcheck themes/joshuaestes/uninstall.sh`
- `UNINSTALL_NO_INTERACTION=1 bats tests >/tmp/bats.log && tail -n 20 /tmp/bats.log`

------
https://chatgpt.com/codex/tasks/task_e_68a55ae1e360832caa8a380cfed12d2a