### PR TITLE
Fix missing local library glob errors

### DIFF
--- a/pms.sh
+++ b/pms.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ####
 # PMS
 #
@@ -66,28 +67,34 @@ fi
 ####
 # Load libraries from the PMS installation followed by any local libraries.
 # This includes generic `.sh` files and shell-specific implementations.
+# Using `find` avoids shell globbing errors when directories are empty.
 #
 # @internal
 ####
-for lib in "$PMS"/lib/*.{sh,$PMS_SHELL}; do
+pms_libs="$(
+    find "$PMS/lib" -maxdepth 1 -type f \( -name '*.sh' -o -name "*.$PMS_SHELL" \)
+)"
+for library_file in $pms_libs; do
     # shellcheck disable=SC1090
-    source "$lib"
+    . "$library_file"
     if [ 1 -eq "${PMS_DEBUG:-0}" ]; then
-        echo "source $lib"
+        echo "source $library_file"
     fi
 done
-unset lib
+unset pms_libs library_file
 
 if [ -d "$PMS_LOCAL/lib" ]; then
-    for local_lib in "$PMS_LOCAL"/lib/*.{sh,$PMS_SHELL}; do
-        [ -f "$local_lib" ] || continue
+    local_libs="$(
+        find "$PMS_LOCAL/lib" -maxdepth 1 -type f \( -name '*.sh' -o -name "*.$PMS_SHELL" \)
+    )"
+    for local_library in $local_libs; do
         # shellcheck disable=SC1090
-        source "$local_lib"
+        . "$local_library"
         if [ 1 -eq "${PMS_DEBUG:-0}" ]; then
-            echo "source $local_lib"
+            echo "source $local_library"
         fi
     done
-    unset local_lib
+    unset local_libs local_library
 fi
 
 _pms_source_file "$HOME/.pms.plugins"

--- a/tests/local_lib_skipped_when_empty.bats
+++ b/tests/local_lib_skipped_when_empty.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/lib"
+    export PMS_SHELL="bash"
+    export PMS_DEBUG=1
+    export PMS_THEME=default
+    export HOME="$BATS_TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+}
+
+@test "pms.sh skips local libraries when none present" {
+    run bash "$PMS/pms.sh" "$PMS_SHELL"
+    [ "$status" -eq 0 ]
+    case "$output" in
+        *"$PMS_LOCAL/lib"*) false ;;
+        *) ;;
+    esac
+}


### PR DESCRIPTION
## Summary
- ensure pms.sh loads libraries using find so missing globs don't error
- document and test skipping local libraries when directory is empty

## Testing
- `shellcheck pms.sh tests/local_lib_skipped_when_empty.bats`
- `bats tests/local_lib_loads_when_present.bats tests/local_lib_skipped_when_empty.bats`
- `bats tests` *(fails: `[ "$status" -eq 0 ]` in tests/plugin_completion_fpath.bats:13)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d78491c4832caa161b13132f59eb