### PR TITLE
Fix library load ordering and add zsh coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@
 - Run `shellcheck` on all modified shell scripts.
 - If tests exist, run them and ensure each test method covers one execution path.
 - Keep files you touch tidy by fixing typos or minor issues you encounter.
+- When sourcing multiple files, load them individually in a deterministic order.

--- a/pms.sh
+++ b/pms.sh
@@ -71,30 +71,25 @@ fi
 #
 # @internal
 ####
-pms_libs="$(
-    find "$PMS/lib" -maxdepth 1 -type f \( -name '*.sh' -o -name "*.$PMS_SHELL" \)
-)"
-for library_file in $pms_libs; do
+# Load core and auxiliary libraries in a stable order. The while loop avoids
+# shell-specific word-splitting issues and guarantees each file is sourced
+# individually.
+while IFS= read -r library_file; do
     # shellcheck disable=SC1090
     . "$library_file"
     if [ 1 -eq "${PMS_DEBUG:-0}" ]; then
         echo "source $library_file"
     fi
-done
-unset pms_libs library_file
+done < <(find "$PMS/lib" -maxdepth 1 -type f \( -name '*.sh' -o -name "*.$PMS_SHELL" \) | sort)
 
 if [ -d "$PMS_LOCAL/lib" ]; then
-    local_libs="$(
-        find "$PMS_LOCAL/lib" -maxdepth 1 -type f \( -name '*.sh' -o -name "*.$PMS_SHELL" \)
-    )"
-    for local_library in $local_libs; do
+    while IFS= read -r local_library; do
         # shellcheck disable=SC1090
         . "$local_library"
         if [ 1 -eq "${PMS_DEBUG:-0}" ]; then
             echo "source $local_library"
         fi
-    done
-    unset local_libs local_library
+    done < <(find "$PMS_LOCAL/lib" -maxdepth 1 -type f \( -name '*.sh' -o -name "*.$PMS_SHELL" \) | sort)
 fi
 
 _pms_source_file "$HOME/.pms.plugins"

--- a/tests/pms_loads_libraries_in_zsh.bats
+++ b/tests/pms_loads_libraries_in_zsh.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+
+setup() {
+    pms_root="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    export PMS="$pms_root"
+    export PMS_LOCAL="$BATS_TEST_TMPDIR/local"
+    mkdir -p "$PMS_LOCAL/plugins"
+    export PMS_DEBUG=0
+    export PMS_THEME=default
+    export HOME="$BATS_TEST_TMPDIR/home"
+    mkdir -p "$HOME"
+}
+
+@test "pms.sh loads libraries when sourced in zsh" {
+    run zsh -c "source \"$PMS/pms.sh\" zsh >/dev/null && type _pms_source_file >/dev/null"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- ensure libraries are sourced individually in deterministic order
- note library loading order in AGENTS guidance
- test zsh sourcing to verify library availability

## Testing
- `shellcheck pms.sh`
- `bats tests`


------
https://chatgpt.com/codex/tasks/task_e_68a5ef343730832cb07d94522522d758