### PR TITLE
Handle missing millisecond precision in timing helper

### DIFF
--- a/lib/core/timing.sh
+++ b/lib/core/timing.sh
@@ -9,17 +9,20 @@ PMS_PLUGIN_TIME_VALUES=()
 
 ####
 # Return the current time in milliseconds.
+# Falls back to seconds when millisecond precision is not available.
 #
 # Usage:
 #   _pms_now
 ####
 _pms_now() {
     local current_time
-    if current_time=$(date +%s%3N 2>/dev/null); then
-        printf '%s\n' "$current_time"
-    else
-        printf '%s000\n' "$(date +%s)"
-    fi
+    current_time=$(date +%s%3N 2>/dev/null)
+    case $current_time in
+        (''|*[!0-9]*)
+            current_time=$(date +%s)000
+            ;;
+    esac
+    printf '%s\n' "$current_time"
 }
 
 ####

--- a/tests/timing_now_fallback_to_seconds.bats
+++ b/tests/timing_now_fallback_to_seconds.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+@test "_pms_now falls back to seconds when milliseconds unavailable" {
+    tmp_dir=$(mktemp -d)
+    PATH="$tmp_dir:$PATH"
+    cat >"$tmp_dir/date" <<'SCRIPT'
+#!/bin/sh
+if [ "$1" = "+%s%3N" ]; then
+    printf '%s\n' "1692553041N"
+    exit 0
+fi
+exec /bin/date "$@"
+SCRIPT
+    chmod +x "$tmp_dir/date"
+    run bash -c '. lib/core/timing.sh; _pms_now'
+    [ "$status" -eq 0 ]
+    case $output in
+        (*[!0-9]*) false ;;
+        (*000) ;;
+        (*) false ;;
+    esac
+}


### PR DESCRIPTION
## Summary
- ensure `_pms_now` gracefully falls back to second precision when millisecond support is absent
- add regression test covering `_pms_now` fallback behaviour

## Testing
- `shellcheck lib/core/timing.sh tests/timing_now_fallback_to_seconds.bats`
- `bats tests/timing_now_fallback_to_seconds.bats tests/plugin_load_timing_diagnostic.bats tests/plugin_load_timing_record.bats`
- `bats tests` *(fails: message formatting, plugin completion; run hangs on interactive test)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f8c2df44832c867f6fb25c826bc6